### PR TITLE
Adding missing QSysInfo to typesystem_core_x11

### DIFF
--- a/PySide2/QtCore/typesystem_core_x11.xml
+++ b/PySide2/QtCore/typesystem_core_x11.xml
@@ -29,4 +29,8 @@
     <!-- Qt5: had to add this recursive object def. This was crucial to get rid of "pure virtual" -->
     <object-type name="TimerInfo"/>
   </object-type>
+  <object-type name="QSysInfo">
+    <enum-type name="Endian"/>
+    <enum-type name="Sizes"/>
+  </object-type>
 </typesystem>


### PR DESCRIPTION
Correct fix for failing builds on Linux

However, I wonder, whether it is possible to inherit "QSysInfo" from common and add just the specific lines for OSX and WIN. My XML skills are just good enough to copy+past this missing part.