### PR TITLE
Add QtWebEngineWidgets, QtWebChannel, and QtWebSockets typesystem files

### DIFF
--- a/PySide2/CMakeLists.txt
+++ b/PySide2/CMakeLists.txt
@@ -23,6 +23,9 @@ find_package(Qt5ScriptTools)
 find_package(Qt5Help)
 find_package(Qt5Declarative)
 find_package(Qt5Multimedia)
+find_package(Qt5WebEngineWidgets)
+find_package(Qt5WebChannel)
+find_package(Qt5WebSockets)
 
 # Configure include based on platform
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/global.h.in"
@@ -114,6 +117,9 @@ CHECK_PACKAGE_FOUND(Qt5Script opt)
 CHECK_PACKAGE_FOUND(Qt5ScriptTools opt)
 CHECK_PACKAGE_FOUND(Qt5Help opt)
 CHECK_PACKAGE_FOUND(Qt5Multimedia opt)
+CHECK_PACKAGE_FOUND(Qt5WebEngineWidgets opt)
+CHECK_PACKAGE_FOUND(Qt5WebChannel opt)
+CHECK_PACKAGE_FOUND(Qt5WebSockets opt)
 
 # note: the order of this list is relevant for dependencies.
 # For instance: Qt5Printsupport must come before Qt5WebKitWidgets
@@ -175,6 +181,15 @@ else()
     set(DISABLE_QtMultimedia 1 PARENT_SCOPE)
 endif()
 message(WARNING "hier in PySide2 ${DISABLE_QtMultimedia}")
+HAS_QT_MODULE(Qt5WebEngineWidgets_FOUND QtWebEngineWidgets)
+HAS_QT_MODULE(Qt5WebChannel_FOUND QtWebChannel)
+if(0)
+    # Doesn't build yet, requires SSL classes in QtNetwork which
+    # Shiboken doesn't seem to pick up yet
+    HAS_QT_MODULE(Qt5WebSockets_FOUND QtWebSockets)
+else()
+    set(DISABLE_QtWebSockets 1 PARENT_SCOPE)
+endif()
 
 # install
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/__init__.py"

--- a/PySide2/QtCore/CMakeLists.txt
+++ b/PySide2/QtCore/CMakeLists.txt
@@ -54,6 +54,9 @@ ${QtCore_GEN_DIR}/qgenericargument_wrapper.cpp
 ${QtCore_GEN_DIR}/qgenericreturnargument_wrapper.cpp
 ${QtCore_GEN_DIR}/qhistorystate_wrapper.cpp
 ${QtCore_GEN_DIR}/qiodevice_wrapper.cpp
+${QtCore_GEN_DIR}/qjsonarray_wrapper.cpp
+${QtCore_GEN_DIR}/qjsonobject_wrapper.cpp
+${QtCore_GEN_DIR}/qjsonvalue_wrapper.cpp
 ${QtCore_GEN_DIR}/qitemselectionmodel_wrapper.cpp
 ${QtCore_GEN_DIR}/qlibraryinfo_wrapper.cpp
 ${QtCore_GEN_DIR}/qline_wrapper.cpp

--- a/PySide2/QtCore/typesystem_core_common.xml
+++ b/PySide2/QtCore/typesystem_core_common.xml
@@ -3990,6 +3990,20 @@
       </inject-code>
     </add-function>
   </value-type>
+  <value-type name="QJsonArray">
+    <extra-includes>
+      <include file-name="QStringList" location="global"/>
+    </extra-includes>
+  </value-type>
+  <value-type name="QJsonObject" />
+  <value-type name="QJsonValue">
+    <enum-type name="Type"/>
+    <extra-includes>
+      <include file-name="QVariant" location="global"/>
+      <include file-name="QJsonArray" location="global"/>
+      <include file-name="QJsonObject" location="global"/>
+    </extra-includes>
+  </value-type>
 
   <object-type name="QEventTransition" since="4.6">
     <modify-function signature="QEventTransition(QState*)">

--- a/PySide2/QtWebChannel/CMakeLists.txt
+++ b/PySide2/QtWebChannel/CMakeLists.txt
@@ -1,0 +1,34 @@
+project(QtWebChannel)
+
+set(QtWebChannel_SRC
+${QtWebChannel_GEN_DIR}/qwebchannel_wrapper.cpp
+${QtWebChannel_GEN_DIR}/qwebchannelabstracttransport_wrapper.cpp
+# module is always needed
+${QtWebChannel_GEN_DIR}/qtwebchannel_module_wrapper.cpp
+)
+
+make_path(QtWebChannel_typesystem_path ${QtCore_SOURCE_DIR} ${QtCore_BINARY_DIR} ${QtWebChannel_SOURCE_DIR})
+
+set(QtWebChannel_include_dirs ${QtWebChannel_SOURCE_DIR}
+                        ${QtWebChannel_BINARY_DIR}
+                        ${Qt5Core_INCLUDE_DIRS}
+                        ${Qt5WebChannel_INCLUDE_DIRS}
+                        ${SHIBOKEN_INCLUDE_DIR}
+                        ${libpyside_SOURCE_DIR}
+                        ${SHIBOKEN_PYTHON_INCLUDE_DIR}
+                        ${QtCore_GEN_DIR}
+                        )
+set(QtWebChannel_libraries    pyside2
+                        ${SHIBOKEN_PYTHON_LIBRARIES}
+                        ${SHIBOKEN_LIBRARY}
+                        ${Qt5WebChannel_LIBRARIES}
+                        ${Qt5Core_LIBRARIES}
+                        )
+
+create_pyside_module(QtWebChannel
+                     QtWebChannel_include_dirs
+                     QtWebChannel_libraries
+                     QtWebChannel_deps
+                     QtWebChannel_typesystem_path
+                     QtWebChannel_SRC
+                     "")

--- a/PySide2/QtWebChannel/typesystem_webchannel.xml
+++ b/PySide2/QtWebChannel/typesystem_webchannel.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<!--
+    This file is part of PySide project.
+    Copyright (C) 2013 Digia Plc and/or its subsidiary(-ies).
+    Contact: PySide team <contact@pyside.org>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+-->
+<typesystem package="PySide2.QtWebChannel">
+  <load-typesystem name="typesystem_core.xml" generate="no"/>
+
+  <object-type name="QWebChannel" />
+  <object-type name="QWebChannelAbstractTransport">
+    <extra-includes>
+      <include file-name="QJsonObject" location="global"/>
+    </extra-includes>
+  </object-type>
+  <!-- Not sure if this will be useful, but commented out for now because
+       the QML module is not yet wrapped.
+  <object-type name="QQmlWebChannel" /> -->
+
+</typesystem>

--- a/PySide2/QtWebEngineWidgets/CMakeLists.txt
+++ b/PySide2/QtWebEngineWidgets/CMakeLists.txt
@@ -1,0 +1,58 @@
+project(QtWebEngineWidgets)
+
+set(QtWebEngineWidgets_SRC
+${QtWebEngineWidgets_GEN_DIR}/qwebenginecertificateerror_wrapper.cpp
+${QtWebEngineWidgets_GEN_DIR}/qwebenginedownloaditem_wrapper.cpp
+#${QtWebEngineWidgets_GEN_DIR}/qwebenginehistory_wrapper.cpp
+${QtWebEngineWidgets_GEN_DIR}/qwebenginehistoryitem_wrapper.cpp
+${QtWebEngineWidgets_GEN_DIR}/qwebenginepage_wrapper.cpp
+${QtWebEngineWidgets_GEN_DIR}/qwebengineprofile_wrapper.cpp
+${QtWebEngineWidgets_GEN_DIR}/qwebenginescript_wrapper.cpp
+#${QtWebEngineWidgets_GEN_DIR}/qwebenginescriptcollection_wrapper.cpp
+#${QtWebEngineWidgets_GEN_DIR}/qwebenginesettings_wrapper.cpp
+${QtWebEngineWidgets_GEN_DIR}/qwebengineview_wrapper.cpp
+# module is always needed
+${QtWebEngineWidgets_GEN_DIR}/qtwebenginewidgets_module_wrapper.cpp
+)
+
+make_path(QtWebEngineWidgets_typesystem_path 
+                            ${QtCore_SOURCE_DIR} ${QtGui_SOURCE_DIR} ${QtWidgets_SOURCE_DIR}
+                            ${QtCore_BINARY_DIR} ${QtGui_BINARY_DIR} ${QtWidgets_BINARY_DIR}
+                            ${QtNetwork_SOURCE_DIR} ${QtNetwork_BINARY_DIR}
+                            ${QtWebEngineWidgets_SOURCE_DIR})
+
+set(QtWebEngineWidgets_include_dirs
+                            ${QtWebEngineWidgets_SOURCE_DIR}
+                            ${QtWebEngineWidgets_BINARY_DIR}
+                            ${Qt5Core_INCLUDE_DIRS}
+                            ${Qt5Gui_INCLUDE_DIRS}
+                            ${Qt5Widgets_INCLUDE_DIRS}
+                            ${Qt5Network_INCLUDE_DIRS}
+                            ${Qt5WebEngineWidgets_INCLUDE_DIRS}
+                            ${SHIBOKEN_INCLUDE_DIR}
+                            ${libpyside_SOURCE_DIR}
+                            ${SHIBOKEN_PYTHON_INCLUDE_DIR}
+                            ${QtCore_GEN_DIR}
+                            ${QtGui_GEN_DIR}
+                            ${QtWidgets_GEN_DIR}
+                            ${QtWebEngineWidgets_GEN_DIR}
+                            ${QtNetwork_GEN_DIR}
+                            )
+set(QtWebEngineWidgets_libraries      pyside2
+                            ${SHIBOKEN_PYTHON_LIBRARIES}
+                            ${SHIBOKEN_LIBRARY}
+                            ${Qt5WebEngineWidgets_LIBRARIES}
+                            ${Qt5Network_LIBRARIES}
+                            ${Qt5Widgets_LIBRARIES}
+                            ${Qt5Gui_LIBRARIES}
+                            ${Qt5Core_LIBRARIES}
+                            )
+set(QtWebEngineWidgets_deps QtWidgets QtNetwork)
+create_pyside_module(QtWebEngineWidgets
+                     QtWebEngineWidgets_include_dirs
+                     QtWebEngineWidgets_libraries
+                     QtWebEngineWidgets_deps
+                     QtWebEngineWidgets_typesystem_path
+                     QtWebEngineWidgets_SRC
+                     "")
+

--- a/PySide2/QtWebEngineWidgets/typesystem_webenginewidgets.xml
+++ b/PySide2/QtWebEngineWidgets/typesystem_webenginewidgets.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0"?>
+<!--
+    This file is part of PySide project.
+    Copyright (C) 2013 Digia Plc and/or its subsidiary(-ies).
+    Contact: PySide team <contact@pyside.org>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+-->
+<typesystem package="PySide2.QtWebEngineWidgets">
+  <load-typesystem name="typesystem_core.xml" generate="no"/>
+  <load-typesystem name="typesystem_gui.xml" generate="no"/>
+  <load-typesystem name="typesystem_widgets.xml" generate="no"/>
+  <load-typesystem name="typesystem_network.xml" generate="no"/>
+
+  <object-type name="QWebEngineCertificateError">
+    <enum-type name="Error"/>
+  </object-type>
+
+  <object-type name="QWebEngineDownloadItem">
+    <enum-type name="DownloadState" />
+  </object-type>
+  
+  <!-- TODO: Deal with private constructor
+  <value-type name="QWebEngineHistory" /> -->
+
+  <value-type name="QWebEngineHistoryItem" />
+
+  <object-type name="QWebEnginePage">
+    <enum-type name="WebAction" />
+    <enum-type name="FindFlag" flags="FindFlags"/>
+    <enum-type name="WebWindowType" />
+    <enum-type name="PermissionPolicy" />
+    <enum-type name="NavigationType" />
+    <enum-type name="Feature" />
+    <enum-type name="FileSelectionMode" />
+    <enum-type name="JavaScriptConsoleMessageLevel" />
+  </object-type>
+
+  <object-type name="QWebEngineProfile">
+    <enum-type name="HttpCacheType" />
+    <enum-type name="PersistentCookiesPolicy" />
+  </object-type>
+
+  <value-type name="QWebEngineScript">
+    <enum-type name="InjectionPoint" />
+    <enum-type name="ScriptWorldId" />
+  </value-type>
+
+  <!-- TODO: Deal with private constructor
+  <value-type name="QWebEngineScriptCollection" /> -->
+
+  <!-- TODO: Deal with private constructor
+  <value-type name="QWebEngineSettings">
+    <enum-type name="FontFamily" />
+    <enum-type name="WebAttribute" />
+    <enum-type name="FontSize" />
+  </value-type> -->
+
+  <object-type name="QWebEngineView" />
+
+</typesystem>

--- a/PySide2/QtWebSockets/CMakeLists.txt
+++ b/PySide2/QtWebSockets/CMakeLists.txt
@@ -1,0 +1,42 @@
+project(QtWebSockets)
+
+set(QtWebSockets_SRC
+${QtWebSockets_GEN_DIR}/qwebsocket_wrapper.cpp
+${QtWebSockets_GEN_DIR}/qwebsocketcorsauthenticator_wrapper.cpp
+${QtWebSockets_GEN_DIR}/qwebsocketserver_wrapper.cpp
+# module is always needed
+${QtWebSockets_GEN_DIR}/qtwebsockets_module_wrapper.cpp
+)
+
+make_path(QtWebSockets_typesystem_path ${QtCore_SOURCE_DIR} ${QtCore_BINARY_DIR} ${QtNetwork_SOURCE_DIR}
+                                       ${QtNetwork_BINARY_DIR} ${QtWebSockets_SOURCE_DIR})
+
+set(QtWebSockets_include_dirs ${QtWebSockets_SOURCE_DIR}
+                        ${QtWebSockets_BINARY_DIR}
+                        ${Qt5Core_INCLUDE_DIRS}
+                        ${Qt5Network_INCLUDE_DIRS}
+                        ${Qt5WebSockets_INCLUDE_DIRS}
+                        ${SHIBOKEN_INCLUDE_DIR}
+                        ${libpyside_SOURCE_DIR}
+                        ${SHIBOKEN_PYTHON_INCLUDE_DIR}
+                        ${QtCore_GEN_DIR}
+                        ${QtWebSockets_GEN_DIR}
+                        ${QtNetwork_GEN_DIR}
+                        )
+set(QtWebSockets_libraries    pyside2
+                        ${SHIBOKEN_PYTHON_LIBRARIES}
+                        ${SHIBOKEN_LIBRARY}
+                        ${Qt5WebSockets_LIBRARIES}
+                        ${Qt5Network_LIBRARIES}
+                        ${Qt5Core_LIBRARIES}
+                        )
+
+set(QtWebEngineWidgets_deps QtNetwork)
+
+create_pyside_module(QtWebSockets
+                     QtWebSockets_include_dirs
+                     QtWebSockets_libraries
+                     QtWebSockets_deps
+                     QtWebSockets_typesystem_path
+                     QtWebSockets_SRC
+                     "")

--- a/PySide2/QtWebSockets/typesystem_websockets.xml
+++ b/PySide2/QtWebSockets/typesystem_websockets.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<!--
+    This file is part of PySide project.
+    Copyright (C) 2013 Digia Plc and/or its subsidiary(-ies).
+    Contact: PySide team <contact@pyside.org>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+-->
+<typesystem package="PySide2.QtWebSockets">
+  <load-typesystem name="typesystem_core.xml" generate="no"/>
+  <load-typesystem name="typesystem_network.xml" generate="no"/>
+
+  <object-type name="QWebSocket">
+    <extra-includes>
+      <include file-name="QTcpSocket" location="global"/>
+    </extra-includes>
+  </object-type>
+  <object-type name="QWebSocketCorsAuthenticator" />
+  <object-type name="QWebSocketServer">
+    <enum-type name="SslMode" />
+    <extra-includes>
+      <include file-name="QWebSocketCorsAuthenticator" location="global" />
+    </extra-includes>
+  </object-type>
+
+</typesystem>

--- a/PySide2/global.h.in
+++ b/PySide2/global.h.in
@@ -419,6 +419,20 @@ QT_END_NAMESPACE
 #  include "pysideqtesttouch.h"
 #endif
 
+#if @Qt5WebEngine_FOUND@
+#  include <QtWebEngineWidgets/QtWebEngineWidgets>
+#endif
+
+#if @Qt5WebChannel_FOUND@
+#  include <QtWebChannel/QtWebChannel>
+#endif
+
+/** Doesn't build yet.
+#if @Qt5WebSockets_FOUND@
+#  include <QtWebSockets/QtWebSockets>
+#endif
+*/
+
 //QtHelp needs to be included after QtSql. Why?
 #include <QtHelp/QtHelp>
 


### PR DESCRIPTION
These are *very* basic right now, but thanks to the contributions that fixed some of the metaobject weirdness the WebEngine view works fine!

There's a problem with some of the classes in the WebEngineWidgets typesystem file though - some of the classes have private constructors, and I haven't been able to figure out how to tell Shiboken to work without one.

The QtWebSockets module has an issue that's perplexing me too. At compile time it's trying to find the symbol `SBK_QSSLCONFIGURATION_IDX`, but can't find it. It seems as if the binding generator when working on QtNetwork can't seem to find any of the SSL-related classes [at the bottom of typesystem_network.xml](https://github.com/PySide/pyside2/blob/master/PySide2/QtNetwork/typesystem_network.xml#L260)