### PR TITLE
Add Qt5 QML modules

### DIFF
--- a/PySide2/CMakeLists.txt
+++ b/PySide2/CMakeLists.txt
@@ -21,8 +21,10 @@ find_package(Qt5OpenGL)
 find_package(Qt5Script)
 find_package(Qt5ScriptTools)
 find_package(Qt5Help)
-find_package(Qt5Declarative)
 find_package(Qt5Multimedia)
+find_package(Qt5Quick)
+find_package(Qt5Qml)
+find_package(Qt5QuickWidgets)
 
 # Configure include based on platform
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/global.h.in"
@@ -114,6 +116,9 @@ CHECK_PACKAGE_FOUND(Qt5Script opt)
 CHECK_PACKAGE_FOUND(Qt5ScriptTools opt)
 CHECK_PACKAGE_FOUND(Qt5Help opt)
 CHECK_PACKAGE_FOUND(Qt5Multimedia opt)
+CHECK_PACKAGE_FOUND(Qt5Quick opt)
+CHECK_PACKAGE_FOUND(Qt5Qml opt)
+CHECK_PACKAGE_FOUND(Qt5QuickWidgets opt)
 
 # note: the order of this list is relevant for dependencies.
 # For instance: Qt5Printsupport must come before Qt5WebKitWidgets
@@ -175,6 +180,9 @@ else()
     set(DISABLE_QtMultimedia 1 PARENT_SCOPE)
 endif()
 message(WARNING "hier in PySide2 ${DISABLE_QtMultimedia}")
+HAS_QT_MODULE(Qt5Quick_FOUND QtQuick)
+HAS_QT_MODULE(Qt5Qml_FOUND QtQml)
+HAS_QT_MODULE(Qt5QuickWidgets_FOUND QtQuickWidgets)
 
 # install
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/__init__.py"

--- a/PySide2/QtQml/CMakeLists.txt
+++ b/PySide2/QtQml/CMakeLists.txt
@@ -1,0 +1,70 @@
+project(QtQml)
+
+set(QtQml_registerType "${QtQml_SOURCE_DIR}/pysideqmlregistertype.cpp")
+
+set(QtQml_SRC
+${QtQml_GEN_DIR}/qjsengine_wrapper.cpp
+${QtQml_GEN_DIR}/qjsvalue_wrapper.cpp
+#${QtQml_GEN_DIR}/qjsvalueiterator_wrapper.cpp
+#${QtQml_GEN_DIR}/qqmlabstracturlinterceptor_wrapper.cpp
+${QtQml_GEN_DIR}/qqmlapplicationengine_wrapper.cpp
+#${QtQml_GEN_DIR}/qqmlcomponent_wrapper.cpp
+${QtQml_GEN_DIR}/qqmlcontext_wrapper.cpp
+${QtQml_GEN_DIR}/qqmlerror_wrapper.cpp
+#${QtQml_GEN_DIR}/qqmldebuggingenabler_wrapper.cpp
+${QtQml_GEN_DIR}/qqmlengine_wrapper.cpp
+${QtQml_GEN_DIR}/qqmlexpression_wrapper.cpp
+#${QtQml_GEN_DIR}/qqmlextensionplugin_wrapper.cpp
+#${QtQml_GEN_DIR}/qqmlfile_wrapper.cpp
+${QtQml_GEN_DIR}/qqmlfileselector_wrapper.cpp
+#${QtQml_GEN_DIR}/qqmlimageproviderbase_wrapper.cpp
+#${QtQml_GEN_DIR}/qqmlincubator_wrapper.cpp
+#${QtQml_GEN_DIR}/qqmllistproperty_wrapper.cpp
+${QtQml_GEN_DIR}/qqmllistreference_wrapper.cpp
+#${QtQml_GEN_DIR}/qqmlparserstatus_wrapper.cpp
+${QtQml_GEN_DIR}/qqmlproperty_wrapper.cpp
+#${QtQml_GEN_DIR}/qqmlpropertymap_wrapper.cpp
+#${QtQml_GEN_DIR}/qqmlpropertyvaluesource_wrapper.cpp
+#${QtQml_GEN_DIR}/qqmlscriptstring_wrapper.cpp
+# module is always needed
+${QtQml_GEN_DIR}/qtqml_module_wrapper.cpp
+)
+
+make_path(QtQml_typesystem_path ${QtCore_SOURCE_DIR} ${QtGui_SOURCE_DIR} ${QtNetwork_SOURCE_DIR}
+                                ${QtCore_BINARY_DIR} ${QtGui_BINARY_DIR} ${QtNetwork_BINARY_DIR}
+                                ${QtQuick_SOURCE_DIR} ${QtQuick_BINARY_DIR}
+                                ${QtQml_SOURCE_DIR})
+
+set(QtQml_include_dirs  ${QtQml_SOURCE_DIR}
+                        ${Qt5Core_INCLUDE_DIRS}
+                        ${Qt5Gui_INCLUDE_DIRS}
+                        ${Qt5Network_INCLUDE_DIRS}
+                        ${Qt5Quick_INCLUDE_DIRS}
+                        ${Qt5Qml_INCLUDE_DIRS}
+                        ${SHIBOKEN_PYTHON_INCLUDE_DIR}
+                        ${SHIBOKEN_INCLUDE_DIR}
+                        ${libpyside_SOURCE_DIR}
+                        ${QtGui_GEN_DIR}
+                        ${QtCore_GEN_DIR}
+                        ${QtNetwork_GEN_DIR}
+                        ${QtQuick_GEN_DIR}
+                        ${QtQml_GEN_DIR})
+
+set(QtQml_libraries pyside2
+                    ${SHIBOKEN_PYTHON_LIBRARIES}
+                    ${Qt5Core_LIBRARIES}
+                    ${Qt5Gui_LIBRARIES}
+                    ${Qt5Network_LIBRARIES}
+                    ${Qt5Quick_LIBRARIES}
+                    ${Qt5Qml_LIBRARIES})
+
+set(QtQml_deps QtGui QtNetwork QtQuick)
+
+create_pyside_module(QtQml
+                     QtQml_include_dirs
+                     QtQml_libraries
+                     QtQml_deps
+                     QtQml_typesystem_path
+                     QtQml_SRC
+#                     "")
+                     QtQml_registerType)

--- a/PySide2/QtQml/pysideqmlregistertype.cpp
+++ b/PySide2/QtQml/pysideqmlregistertype.cpp
@@ -1,0 +1,362 @@
+/*
+ * This file is part of the Shiboken Python Bindings Generator project.
+ *
+ * Copyright (C) 2013 Digia Plc and/or its subsidiary(-ies).
+ *
+ * Contact: PySide team <contact@pyside.org>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "pysideqmlregistertype.h"
+// Qt
+#include <QObject>
+#include <QQmlEngine>
+#include <QMutex>
+// shiboken
+#include <typeresolver.h>
+#include <gilstate.h>
+#include <sbkdbg.h>
+// pyside
+#include <pyside.h>
+#include <dynamicqmetaobject.h>
+#include <pysideproperty.h>
+
+// auto generated headers
+#include "qquickitem_wrapper.h"
+#include "pyside2_qtcore_python.h"
+#include "pyside2_qtquick_python.h"
+#include "pyside2_qtqml_python.h"
+
+#ifndef PYSIDE_MAX_QML_TYPES
+// Maximum number of different types the user can export to QML using qmlRegisterType.
+// 
+// Qt5 Note: this is a vestige of the old QtDeclarative qmlRegisterType - it might be worth
+// checking if this is still relevant to QtQml or if it's higher/lower.
+#define PYSIDE_MAX_QML_TYPES 50
+#endif
+
+// Forward declarations
+static void propListMetaCall(PySideProperty* pp, PyObject* self, QMetaObject::Call call, void** args);
+
+
+// All registered python types
+static PyObject* pyTypes[PYSIDE_MAX_QML_TYPES];
+static void (*createFuncs[PYSIDE_MAX_QML_TYPES])(void*);
+
+// Mutex used to avoid race condition on PySide::nextQObjectMemoryAddr
+static QMutex nextQmlElementMutex;
+
+template<int N>
+struct ElementFactoryBase
+{
+    static void createInto(void* memory)
+    {
+        QMutexLocker locker(&nextQmlElementMutex);
+        PySide::setNextQObjectMemoryAddr(memory);
+        Shiboken::GilState state;
+        PyObject* obj = PyObject_CallObject(pyTypes[N], 0);
+        if (!obj || PyErr_Occurred())
+            PyErr_Print();
+        PySide::setNextQObjectMemoryAddr(0);
+    }
+};
+
+template<int N>
+struct ElementFactory : ElementFactoryBase<N>
+{
+    static void init()
+    {
+        createFuncs[N] = &ElementFactoryBase<N>::createInto;
+        ElementFactory<N-1>::init();
+    }
+};
+
+template<>
+struct  ElementFactory<0> : ElementFactoryBase<0>
+{
+    static void init()
+    {
+        createFuncs[0] = &ElementFactoryBase<0>::createInto;
+    }
+};
+
+int PySide::qmlRegisterType(PyObject* pyObj, const char* uri, int versionMajor, int versionMinor, const char* qmlName)
+{
+    using namespace Shiboken;
+
+    static PyTypeObject* qobjectType = Shiboken::Conversions::getPythonTypeObject("QObject*");
+    static PyTypeObject* qquickType = Shiboken::Conversions::getPythonTypeObject("QQuickItem*");
+    assert(qobjectType);
+    static int nextType = 0;
+
+    if (nextType >= PYSIDE_MAX_QML_TYPES) {
+        PyErr_Format(PyExc_TypeError, "QML doesn't really like language bindings, so you can only export %d types to QML.", PYSIDE_MAX_QML_TYPES);
+        return -1;
+    }
+
+    if (!PySequence_Contains(((PyTypeObject*)pyObj)->tp_mro, (PyObject*)qobjectType)) {
+        PyErr_Format(PyExc_TypeError, "A type inherited from %s expected, got %s.", qobjectType->tp_name, ((PyTypeObject*)pyObj)->tp_name);
+        return -1;
+    }
+
+    bool isQuickType = PySequence_Contains(((PyTypeObject*)pyObj)->tp_mro, (PyObject*)qquickType);
+
+    QMetaObject* metaObject = reinterpret_cast<QMetaObject*>(ObjectType::getTypeUserData(reinterpret_cast<SbkObjectType*>(pyObj)));
+    Q_ASSERT(metaObject);
+
+    // Inc ref the type object, don't worry about dec ref them because there's no way to unregister a QML type
+    Py_INCREF(pyObj);
+
+    // All ready... now the ugly code begins... :-)
+    pyTypes[nextType] = pyObj;
+
+    // Init proxy object static meta object
+    QQmlPrivate::RegisterType type;
+    type.version = 0;
+    if (isQuickType) {
+        type.typeId = qMetaTypeId<QQuickItem*>();
+        type.listId = qMetaTypeId<QQmlListProperty<QQuickItem> >();
+
+        type.attachedPropertiesFunction = QQmlPrivate::attachedPropertiesFunc<QQuickItem>();
+        type.attachedPropertiesMetaObject = QQmlPrivate::attachedPropertiesMetaObject<QQuickItem>();
+
+        type.parserStatusCast = QQmlPrivate::StaticCastSelector<QQuickItem, QQmlParserStatus>::cast();
+        type.valueSourceCast = QQmlPrivate::StaticCastSelector<QQuickItem, QQmlPropertyValueSource>::cast();
+        type.valueInterceptorCast = QQmlPrivate::StaticCastSelector<QQuickItem, QQmlPropertyValueInterceptor>::cast();
+    } else {
+        type.typeId = qMetaTypeId<QObject*>();
+        type.listId = qMetaTypeId<QQmlListProperty<QObject> >();
+        type.attachedPropertiesFunction = QQmlPrivate::attachedPropertiesFunc<QObject>();
+        type.attachedPropertiesMetaObject = QQmlPrivate::attachedPropertiesMetaObject<QObject>();
+
+        type.parserStatusCast = QQmlPrivate::StaticCastSelector<QObject, QQmlParserStatus>::cast();
+        type.valueSourceCast = QQmlPrivate::StaticCastSelector<QObject, QQmlPropertyValueSource>::cast();
+        type.valueInterceptorCast = QQmlPrivate::StaticCastSelector<QObject, QQmlPropertyValueInterceptor>::cast();
+    }
+    type.objectSize = PySide::getSizeOfQObject(reinterpret_cast<SbkObjectType*>(pyObj));
+    type.create = createFuncs[nextType];
+    type.uri = uri;
+    type.versionMajor = versionMajor;
+    type.versionMinor = versionMinor;
+    type.elementName = qmlName;
+    type.metaObject = metaObject;
+
+    type.extensionObjectCreate = 0;
+    type.extensionMetaObject = 0;
+    type.customParser = 0;
+
+    int qmlTypeId = QQmlPrivate::qmlregister(QQmlPrivate::TypeRegistration, &type);
+    ++nextType;
+    return qmlTypeId;
+}
+
+extern "C"
+{
+
+// This is the user data we store in the property.
+struct QmlListProperty
+{
+    PyTypeObject* type;
+    PyObject* append;
+    PyObject* at;
+    PyObject* clear;
+    PyObject* count;
+};
+
+static int propListTpInit(PyObject* self, PyObject* args, PyObject* kwds)
+{
+    static const char *kwlist[] = {"type", "append", "at", "clear", "count", 0};
+    PySideProperty* pySelf = reinterpret_cast<PySideProperty*>(self);
+    QmlListProperty* data = new QmlListProperty;
+    memset(data, 0, sizeof(QmlListProperty));
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwds,
+                                     "OO|OOO:QtQml.ListProperty", (char**) kwlist,
+                                     &data->type,
+                                     &data->append,
+                                     &data->at,
+                                     &data->clear,
+                                     &data->count)) {
+        return 0;
+    }
+    PySide::Property::setMetaCallHandler(pySelf, &propListMetaCall);
+    PySide::Property::setTypeName(pySelf, "QQmlListProperty<QQuickItem>");
+    PySide::Property::setUserData(pySelf, data);
+
+    return 1;
+}
+
+void propListTpFree(void* self)
+{
+    PySideProperty* pySelf = reinterpret_cast<PySideProperty*>(self);
+    delete reinterpret_cast<QmlListProperty*>(PySide::Property::userData(pySelf));
+    // calls base type constructor
+    Py_TYPE(pySelf)->tp_base->tp_free(self);
+}
+
+PyTypeObject PropertyListType = {
+    PyVarObject_HEAD_INIT(0, 0)
+    "ListProperty",            /*tp_name*/
+    sizeof(PySideProperty),    /*tp_basicsize*/
+    0,                         /*tp_itemsize*/
+    0,                         /*tp_dealloc*/
+    0,                         /*tp_print*/
+    0,                         /*tp_getattr*/
+    0,                         /*tp_setattr*/
+    0,                         /*tp_compare*/
+    0,                         /*tp_repr*/
+    0,                         /*tp_as_number*/
+    0,                         /*tp_as_sequence*/
+    0,                         /*tp_as_mapping*/
+    0,                         /*tp_hash */
+    0,                         /*tp_call*/
+    0,                         /*tp_str*/
+    0,                         /*tp_getattro*/
+    0,                         /*tp_setattro*/
+    0,                         /*tp_as_buffer*/
+    Py_TPFLAGS_DEFAULT,        /*tp_flags*/
+    0,                         /*tp_doc */
+    0,                         /*tp_traverse */
+    0,                         /*tp_clear */
+    0,                         /*tp_richcompare */
+    0,                         /*tp_weaklistoffset */
+    0,                         /*tp_iter */
+    0,                         /*tp_iternext */
+    0,                         /*tp_methods */
+    0,                         /*tp_members */
+    0,                         /*tp_getset */
+    &PySidePropertyType,       /*tp_base */
+    0,                         /*tp_dict */
+    0,                         /*tp_descr_get */
+    0,                         /*tp_descr_set */
+    0,                         /*tp_dictoffset */
+    propListTpInit,            /*tp_init */
+    0,                         /*tp_alloc */
+    0,                         /*tp_new */
+    propListTpFree,            /*tp_free */
+    0,                         /*tp_is_gc */
+    0,                         /*tp_bases */
+    0,                         /*tp_mro */
+    0,                         /*tp_cache */
+    0,                         /*tp_subclasses */
+    0,                         /*tp_weaklist */
+    0,                         /*tp_del */
+};
+
+} // extern "C"
+
+// Implementation of QQmlListProperty<T>::AppendFunction callback
+void propListAppender(QQmlListProperty<QQuickItem>* propList, QQuickItem* item)
+{
+    Shiboken::GilState state;
+
+    Shiboken::AutoDecRef args(PyTuple_New(2));
+    PyTuple_SET_ITEM(args, 0, Shiboken::Conversions::pointerToPython((SbkObjectType*)SbkPySide2_QtCoreTypes[SBK_QOBJECT_IDX], propList->object));
+    PyTuple_SET_ITEM(args, 1, Shiboken::Conversions::pointerToPython((SbkObjectType*)SbkPySide2_QtQuickTypes[SBK_QQUICKITEM_IDX], item));
+
+    QmlListProperty* data = reinterpret_cast<QmlListProperty*>(propList->data);
+    Shiboken::AutoDecRef retVal(PyObject_CallObject(data->append, args));
+
+    if (PyErr_Occurred())
+        PyErr_Print();
+}
+
+// Implementation of QQmlListProperty<T>::CountFunction callback
+int propListCount(QQmlListProperty<QQuickItem>* propList)
+{
+    Shiboken::GilState state;
+
+    Shiboken::AutoDecRef args(PyTuple_New(1));
+    PyTuple_SET_ITEM(args, 0, Shiboken::Conversions::pointerToPython((SbkObjectType*)SbkPySide2_QtCoreTypes[SBK_QOBJECT_IDX], propList->object));
+
+    QmlListProperty* data = reinterpret_cast<QmlListProperty*>(propList->data);
+    Shiboken::AutoDecRef retVal(PyObject_CallObject(data->count, args));
+
+    // Check return type
+    int cppResult = 0;
+    PythonToCppFunc pythonToCpp;
+    if (PyErr_Occurred())
+        PyErr_Print();
+    else if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), retVal)))
+        pythonToCpp(retVal, &cppResult);
+    return cppResult;
+}
+
+// Implementation of QQmlListProperty<T>::AtFunction callback
+QQuickItem* propListAt(QQmlListProperty<QQuickItem>* propList, int index)
+{
+    Shiboken::GilState state;
+
+    Shiboken::AutoDecRef args(PyTuple_New(2));
+    PyTuple_SET_ITEM(args, 0, Shiboken::Conversions::pointerToPython((SbkObjectType*)SbkPySide2_QtCoreTypes[SBK_QOBJECT_IDX], propList->object));
+    PyTuple_SET_ITEM(args, 1, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &index));
+
+    QmlListProperty* data = reinterpret_cast<QmlListProperty*>(propList->data);
+    Shiboken::AutoDecRef retVal(PyObject_CallObject(data->at, args));
+
+    QQuickItem* result = 0;
+    if (PyErr_Occurred())
+        PyErr_Print();
+    else if (PyType_IsSubtype(Py_TYPE(retVal), data->type))
+        Shiboken::Conversions::pythonToCppPointer((SbkObjectType*)SbkPySide2_QtCoreTypes[SBK_QQUICKITEM_IDX], retVal, &result);
+    return result;
+}
+
+// Implementation of QQmlListProperty<T>::ClearFunction callback
+void propListClear(QQmlListProperty<QQuickItem>* propList)
+{
+    Shiboken::GilState state;
+
+    Shiboken::AutoDecRef args(PyTuple_New(1));
+    PyTuple_SET_ITEM(args, 0, Shiboken::Conversions::pointerToPython((SbkObjectType*)SbkPySide2_QtCoreTypes[SBK_QOBJECT_IDX], propList->object));
+
+    QmlListProperty* data = reinterpret_cast<QmlListProperty*>(propList->data);
+    Shiboken::AutoDecRef retVal(PyObject_CallObject(data->clear, args));
+
+    if (PyErr_Occurred())
+        PyErr_Print();
+}
+
+// qt_metacall specialization for ListProperties
+static void propListMetaCall(PySideProperty* pp, PyObject* self, QMetaObject::Call call, void** args)
+{
+    if (call != QMetaObject::ReadProperty)
+        return;
+
+    QmlListProperty* data = reinterpret_cast<QmlListProperty*>(PySide::Property::userData(pp));
+    QObject* qobj;
+    Shiboken::Conversions::pythonToCppPointer((SbkObjectType*)SbkPySide2_QtCoreTypes[SBK_QOBJECT_IDX], self, &qobj);
+    QQmlListProperty<QQuickItem> declProp(qobj, data, &propListAppender, &propListCount, &propListAt, &propListClear);
+
+    // Copy the data to the memory location requested by the meta call
+    void* v = args[0];
+    *reinterpret_cast<QQmlListProperty<QQuickItem>*>(v) = declProp;
+}
+
+
+void PySide::initQmlSupport(PyObject* module)
+{
+    ElementFactory<PYSIDE_MAX_QML_TYPES - 1>::init();
+
+    // Export QmlListProperty type
+    if (PyType_Ready(&PropertyListType) < 0)
+        return;
+
+    Py_INCREF((PyObject*)&PropertyListType);
+    PyModule_AddObject(module, PropertyListType.tp_name, (PyObject*)&PropertyListType);
+
+}
+

--- a/PySide2/QtQml/pysideqmlregistertype.h
+++ b/PySide2/QtQml/pysideqmlregistertype.h
@@ -1,0 +1,57 @@
+/*
+ * This file is part of the Shiboken Python Bindings Generator project.
+ *
+ * Copyright (C) 2013 Digia Plc and/or its subsidiary(-ies).
+ *
+ * Contact: PySide team <contact@pyside.org>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef PYSIDEQMLREGISTERTYPE_H
+#define PYSIDEQMLREGISTERTYPE_H
+
+#include <Python.h>
+
+struct SbkObjectType;
+
+namespace PySide
+{
+
+extern void* nextQmlElementMemoryAddr;
+
+/**
+ * Init the QML support doing things like registering QtQml.ListProperty and create the necessary stuff for
+ * qmlRegisterType.
+ *
+ * \param module QtQml python module
+ */
+void initQmlSupport(PyObject* module);
+
+/**
+ * PySide implementation of qmlRegisterType<T> function.
+ *
+ * \param pyObj Python type to be registered.
+ * \param uri QML element uri.
+ * \param versionMajor QML component major version.
+ * \param versionMinor QML component minor version.
+ * \param qmlName QML element name
+ * \return the metatype id of the registered type.
+ */
+int qmlRegisterType(PyObject* pyObj, const char* uri, int versionMajor, int versionMinor, const char* qmlName);
+
+}
+
+#endif

--- a/PySide2/QtQml/typesystem_qml.xml
+++ b/PySide2/QtQml/typesystem_qml.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0"?>
+<!--
+    This file is part of PySide project.
+    Copyright (C) 2013 Digia Plc and/or its subsidiary(-ies).
+    Contact: PySide team <contact@pyside.org>
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+-->
+<typesystem package="PySide2.QtQml">
+    <load-typesystem name="typesystem_core.xml" generate="no"/>
+    <load-typesystem name="typesystem_network.xml" generate="no"/>
+    <load-typesystem name="typesystem_gui.xml" generate="no"/>
+    <load-typesystem name="typesystem_quick.xml" generate="no"/>
+
+    <add-function signature="qmlRegisterType(PyTypeObject, const char*, int, int, const char*)" return-type="int">
+        <inject-documentation format="target" mode="append">
+            This function registers the Python type in the QML system with the name qmlName, in the library imported from uri having the version number composed from versionMajor and versionMinor.
+            Returns the QML type id.
+
+            For example, this registers a Python class MySliderItem as a QML type named Slider for version 1.0 of a module called "com.mycompany.qmlcomponents":
+
+            ::
+
+                qmlRegisterType(MySliderItem, "com.mycompany.qmlcomponents", 1, 0, "Slider")
+
+            Once this is registered, the type can be used in QML by importing the specified module name and version number:
+
+            ::
+
+                import com.mycompany.qmlcomponents 1.0
+
+                Slider { ... }
+
+            Note that it's perfectly reasonable for a library to register types to older versions than the actual version of the library. Indeed, it is normal for the new library to allow QML written to previous versions to continue to work, even if more advanced versions of some of its types are available.
+        </inject-documentation>
+
+        <inject-code class="target">
+        int %0 = PySide::qmlRegisterType(%ARGUMENT_NAMES);
+        %PYARG_0 = %CONVERTTOPYTHON[int](%0);
+        </inject-code>
+    </add-function>
+
+    <enum-type identified-by-value="QML_HAS_ATTACHED_PROPERTIES">
+        <extra-includes>
+            <include file-name="QtQuick" location="global"/>
+            <include file-name="QtQml" location="global"/>
+            <!-- FIXME The include tag doesn't work on modules -->
+            <include file-name="pysideqmlregistertype.h" location="local"/>
+        </extra-includes>
+    </enum-type>
+
+    <inject-code class="target" position="end">
+    PySide::initQmlSupport(module);
+    </inject-code>
+
+    <object-type name="QJSEngine">
+        <add-function signature="toScriptValue(const QVariant&amp;)" return-type="QJSValue">
+            <inject-code class="target" position="end">
+                %RETURN_TYPE retval = %CPPSELF.%FUNCTION_NAME(%1);
+                return %CONVERTTOPYTHON[%RETURN_TYPE](retval);
+            </inject-code>
+        </add-function>
+    </object-type>
+    <value-type name="QJSValue">
+        <enum-type name="SpecialValue" />
+    </value-type>
+    <!-- TODO: Attempts to use private members/operators
+    <value-type name="QJSValueIterator" /> -->
+
+    <!-- TODO: Figure out what's causing this abstract class
+         to fail.
+    <value-type name="QQmlAbstractUrlInterceptor">
+        <enum-type name="DataType" />
+    </value-type> -->
+    <object-type name="QQmlApplicationEngine" />
+    <!-- TODO: More private method errors
+    <object-type name="QQmlComponent">
+        <enum-type name="CompilationMode" />
+        <enum-type name="Status" />
+    </object-type> -->
+    <object-type name="QQmlContext" />
+    <value-type name="QQmlError" />
+    <!-- <object-type name="QQmlDebuggingEnabler" /> -->
+    <object-type name="QQmlEngine">
+        <enum-type name="ObjectOwnership" />
+    </object-type>
+    <object-type name="QQmlExpression" />
+    <!-- TODO: Abstract class
+    <value-type name="QQmlExtensionPlugin" /> -->
+    <!-- qRegisterMetaType issues
+    <value-type name="QQmlFile">
+        <enum-type name="Status" />
+    </value-type> -->
+    <object-type name="QQmlFileSelector" />
+    <!-- TODO: Abstract class
+    <value-type name="QQmlImageProviderBase">
+        <enum-type name="IncubationMode" />
+        <enum-type name="Flag" flags="Flags" />
+    </value-type> -->
+    <!-- TODO: More constructor issues
+    <value-type name="QQmlIncubator">
+        <enum-type name="IncubationMode" />
+        <enum-type name="Status" />
+    </value-type> -->
+
+    <!-- TODO: Gets this error when parsing:
+        Could not find type '::T*' for use in 'toPython' conversion. Make sure to use the full C++ name, e.g. 'Namespace::Class'.
+    <value-type name="QQmlListProperty" /> -->
+    <value-type name="QQmlListReference" />
+    <!-- TODO: Constructor issues
+    <value-type name="QQmlParserStatus" /> -->
+    <value-type name="QQmlProperty">
+        <enum-type name="PropertyTypeCategory" />
+        <enum-type name="Type" />
+    </value-type>
+    <!-- TODO: these fail too
+    <value-type name="QQmlPropertyMap" />
+    <value-type name="QQmlPropertyValueSource" />
+    <value-type name="QQmlScriptString" /> -->
+</typesystem>

--- a/PySide2/QtQuick/CMakeLists.txt
+++ b/PySide2/QtQuick/CMakeLists.txt
@@ -1,0 +1,48 @@
+project(QtQuick)
+
+set(QtQuick_SRC
+#${QtQuick_GEN_DIR}/qquickframebufferobject_wrapper.cpp
+#${QtQuick_GEN_DIR}/qquicktexturefactory_wrapper.cpp
+${QtQuick_GEN_DIR}/qquickimageprovider_wrapper.cpp
+#${QtQuick_GEN_DIR}/qquicktransform_wrapper.cpp
+${QtQuick_GEN_DIR}/qquickitem_wrapper.cpp
+#${QtQuick_GEN_DIR}/qquickitemgrabresult_wrapper.cpp
+#${QtQuick_GEN_DIR}/qquickpainteditem_wrapper.cpp
+#${QtQuick_GEN_DIR}/qquickrendercontrol_wrapper.cpp
+${QtQuick_GEN_DIR}/qquicktextdocument_wrapper.cpp
+${QtQuick_GEN_DIR}/qquickview_wrapper.cpp
+${QtQuick_GEN_DIR}/qquickwindow_wrapper.cpp
+# module is always needed
+${QtQuick_GEN_DIR}/qtquick_module_wrapper.cpp
+)
+
+make_path(QtQuick_typesystem_path ${QtCore_SOURCE_DIR} ${QtGui_SOURCE_DIR} ${QtCore_BINARY_DIR}
+                                  ${QtGui_BINARY_DIR}
+                                  ${QtQuick_SOURCE_DIR})
+
+set(QtQuick_include_dirs  ${QtQuick_SOURCE_DIR}
+                          ${Qt5Core_INCLUDE_DIRS}
+                          ${Qt5Gui_INCLUDE_DIRS}
+                          ${Qt5Quick_INCLUDE_DIRS}
+                          ${SHIBOKEN_PYTHON_INCLUDE_DIR}
+                          ${SHIBOKEN_INCLUDE_DIR}
+                          ${libpyside_SOURCE_DIR}
+                          ${QtGui_GEN_DIR}
+                          ${QtCore_GEN_DIR}
+                          ${QtQuick_GEN_DIR})
+
+set(QtQuick_libraries pyside2
+                      ${SHIBOKEN_PYTHON_LIBRARIES}
+                      ${Qt5Core_LIBRARIES}
+                      ${Qt5Gui_LIBRARIES}
+                      ${Qt5Quick_LIBRARIES})
+
+set(QtQml_deps QtGui)
+
+create_pyside_module(QtQuick
+                     QtQuick_include_dirs
+                     QtQuick_libraries
+                     QtQuick_deps
+                     QtQuick_typesystem_path
+                     QtQuick_SRC
+                     "")

--- a/PySide2/QtQuick/typesystem_quick.xml
+++ b/PySide2/QtQuick/typesystem_quick.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0"?>
+<!--
+    This file is part of PySide project.
+    Copyright (C) 2013 Digia Plc and/or its subsidiary(-ies).
+    Contact: PySide team <contact@pyside.org>
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+-->
+<typesystem package="PySide2.QtQuick">
+    <load-typesystem name="typesystem_core.xml" generate="no"/>
+    <load-typesystem name="typesystem_gui.xml" generate="no"/>
+
+    <!-- TODO: Abstract
+    <object-type name="QQuickFramebufferObject" /> -->
+
+    <!-- TODO: Abstract
+    <object-type name="QQuickTextureFactory" /> -->
+    <object-type name="QQuickImageProvider" />
+
+    <!-- TODO: private
+    <object-type name="QQuickTransform" /> -->
+    <object-type name="QQuickItem">
+        <enum-type name="Flag" flags="Flags" />
+        <enum-type name="ItemChange" />
+        <enum-type name="TransformOrigin" />
+        <!-- TODO: Find a way to wrap `union ItemChangeData {}` -->
+    </object-type>
+
+    <!-- private
+    <object-type name="QQuickItemGrabResult" /> -->
+
+    <!-- `unimplemented pure virtual method 'paint' in 'QQuickPaintedItemWrapper'`
+    <object-type name="QQuickPaintedItem">
+        <enum-type name="RenderTarget" />
+        <enum-type name="PerformanceHint" flags="PerformanceHints" />
+    </object-type> -->
+
+    <!-- private
+    <object-type name="QQuickRenderControl" /> -->
+
+    <object-type name="QQuickTextDocument" />
+
+    <object-type name="QQuickView">
+        <enum-type name="ResizeMode" />
+        <enum-type name="Status" />
+    </object-type>
+
+    <object-type name="QQuickWindow">
+        <enum-type name="CreateTextureOption" flags="CreateTextureOptions" />
+        <enum-type name="RenderStage" />
+        <enum-type name="SceneGraphError" />
+    </object-type>
+
+    <!-- TODO: the scene graph (QSG*) classes -->
+
+</typesystem>

--- a/PySide2/QtQuickWidgets/CMakeLists.txt
+++ b/PySide2/QtQuickWidgets/CMakeLists.txt
@@ -1,0 +1,52 @@
+project(QtQuickWidgets)
+
+set(QtQuickWidgets_SRC
+${QtQuickWidgets_GEN_DIR}/qquickwidget_wrapper.cpp
+# module is always needed
+${QtQuickWidgets_GEN_DIR}/qtquickwidgets_module_wrapper.cpp
+)
+
+make_path(QtQuickWidgets_typesystem_path ${QtCore_SOURCE_DIR} ${QtGui_SOURCE_DIR} ${QtWidgets_SOURCE_DIR}
+                                         ${QtCore_BINARY_DIR} ${QtGui_BINARY_DIR} ${QtWidgets_BINARY_DIR}
+                                         ${QtNetwork_SOURCE_DIR} ${QtNetwork_BINARY_DIR} ${QtQuick_SOURCE_DIR}
+                                         ${QtQuick_BINARY_DIR} ${QtQml_SOURCE_DIR} ${QtQml_BINARY_DIR}
+                                         ${QtQuickWidgets_SOURCE_DIR})
+
+set(QtQuickWidgets_include_dirs  ${QtQuickWidgets_SOURCE_DIR}
+                                 ${Qt5Core_INCLUDE_DIRS}
+                                 ${Qt5Gui_INCLUDE_DIRS}
+                                 ${Qt5Widgets_INCLUDE_DIRS}
+                                 ${Qt5Network_INCLUDE_DIRS}
+                                 ${Qt5Quick_INCLUDE_DIRS}
+                                 ${Qt5Qml_INCLUDE_DIRS}
+                                 ${Qt5QuickWidgets_INCLUDE_DIRS}
+                                 ${SHIBOKEN_PYTHON_INCLUDE_DIR}
+                                 ${SHIBOKEN_INCLUDE_DIR}
+                                 ${libpyside_SOURCE_DIR}
+                                 ${QtGui_GEN_DIR}
+                                 ${QtCore_GEN_DIR}
+                                 ${QtWidgets_GEN_DIR}
+                                 ${QtNetwork_GEN_DIR}
+                                 ${QtQuick_GEN_DIR}
+                                 ${QtQml_GEN_DIR}
+                                 ${QtQuickWidgets_GEN_DIR})
+
+set(QtQuickWidgets_libraries pyside2
+                             ${SHIBOKEN_PYTHON_LIBRARIES}
+                             ${Qt5Core_LIBRARIES}
+                             ${Qt5Gui_LIBRARIES}
+                             ${Qt5Network_LIBRARIES}
+                             ${Qt5Widgets_LIBRARIES}
+                             ${Qt5Quick_LIBRARIES}
+                             ${Qt5Qml_LIBRARIES}
+                             ${Qt5QuickWidgets_LIBRARIES})
+
+set(QtQuickWidgets_deps QtGui QtQml QtQuick QtWidgets)
+
+create_pyside_module(QtQuickWidgets
+                     QtQuickWidgets_include_dirs
+                     QtQuickWidgets_libraries
+                     QtQuickWidgets_deps
+                     QtQuickWidgets_typesystem_path
+                     QtQuickWidgets_SRC
+                     "")

--- a/PySide2/QtQuickWidgets/typesystem_quickwidgets.xml
+++ b/PySide2/QtQuickWidgets/typesystem_quickwidgets.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<!--
+    This file is part of PySide project.
+    Copyright (C) 2013 Digia Plc and/or its subsidiary(-ies).
+    Contact: PySide team <contact@pyside.org>
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+-->
+<typesystem package="PySide2.QtQuickWidgets">
+    <load-typesystem name="typesystem_core.xml" generate="no"/>
+    <load-typesystem name="typesystem_gui.xml" generate="no"/>
+    <load-typesystem name="typesystem_quick.xml" generate="no"/>
+    <load-typesystem name="typesystem_qml.xml" generate="no"/>
+    <load-typesystem name="typesystem_widgets.xml" generate="no"/>
+
+    
+    <object-type name="QQuickWidget">
+        <enum-type name="ResizeMode" />
+        <enum-type name="Status" />
+    </object-type>
+</typesystem>

--- a/PySide2/global.h.in
+++ b/PySide2/global.h.in
@@ -419,6 +419,18 @@ QT_END_NAMESPACE
 #  include "pysideqtesttouch.h"
 #endif
 
+#if @Qt5Quick_FOUND@
+#  include <QtQuick/QtQuick>
+#endif
+
+#if @Qt5Qml_FOUND@
+#  include <QtQml/QtQml>
+#endif
+
+#if @Qt5QuickWidgets_FOUND@
+#  include <QtQuickWidgets/QtQuickWidgets>
+#endif
+
 //QtHelp needs to be included after QtSql. Why?
 #include <QtHelp/QtHelp>
 


### PR DESCRIPTION
This PR adds the following modules:

 * QtQuick (*partially*)
 * QtQml
 * QtQuickWidgets

I could *not* wrap my head around a lot of the classes in Qml and Quick - I hope that someone else might know better how to do these! Because of these issues, I did not yet add all the scenegraph (QSG*) classes to QtQuick as I figured it made sense to focuse on the Qml stuff for now. Though if you'd like the whole thing wrapped before commiting I can do that

I also ported `qmlRegisterType` over from the old QtDeclarative module. It was surprisingly easy, and seems to work fine after some superficial testing in the Python REPL but definitely gonna need to get the unit tests up and running!

The `QJSEngine` class also contains a wrapper around the template function `toScriptValue` - I have not yet done `fromScriptValue`, but calling `toVariant()` on a script value does exactly what that would have done anyways.

And QML seems to work great!

![](https://i.imgur.com/xLBDqDL.png)