### PR TITLE
Fix segfault when instantiating QGuiApplication

### DIFF
--- a/PySide2/QtGui/glue/qguiapplication_init.cpp
+++ b/PySide2/QtGui/glue/qguiapplication_init.cpp
@@ -3,7 +3,6 @@ extern PyObject* moduleQtGui;
 
 static int QGuiApplicationArgCount;
 static char** QGuiApplicationArgValues;
-static const char QAPP_MACRO[] = "qGuiApp";
 
 bool QGuiApplicationConstructorStart(PyObject* argv)
 {
@@ -17,15 +16,6 @@ bool QGuiApplicationConstructorStart(PyObject* argv)
 
 void QGuiApplicationConstructorEnd(PyObject* self)
 {
-    // Verify if qApp is in main module
-    PyObject* globalsDict = PyEval_GetGlobals();
-    if (globalsDict) {
-        PyObject* qAppObj = PyDict_GetItemString(globalsDict, QAPP_MACRO);
-        if (qAppObj)
-            PyDict_SetItemString(globalsDict, QAPP_MACRO, self);
-    }
-
-    PyObject_SetAttrString(moduleQtGui, QAPP_MACRO, self);
     PySide::registerCleanupFunction(&PySide::destroyQCoreApplication);
     Py_INCREF(self);
 }

--- a/PySide2/QtGui/typesystem_gui_common.xml
+++ b/PySide2/QtGui/typesystem_gui_common.xml
@@ -3253,10 +3253,6 @@
   <rejection class="QWindow" function-name="nativeEvent"/>"
 
   <!-- Qt5: here the new QGuiApplication and related things -->
-  <!-- qApp macro -->
-  <inject-code class="native" position="beginning">
-    PyObject* moduleQtGui;
-  </inject-code>
   <object-type name="QGuiApplication">
     <!-- Qt5: gone <enum-type name="ColorSpec"/> -->
     <!-- Qt5: gone <enum-type name="Type"/> -->


### PR DESCRIPTION
If you try and instantiate `QGuiApplication`, PySide2 will segfault because it tries to set the `qGuiApp` property of the `QtGui` module, but that property wasn't initialized yet. [Looking at the documentation](http://doc.qt.io/qt-5/qguiapplication.html), this module doesn't seem to have any application-related macros anyway so this PR just removes the `qGuiApp` stuff.