### PR TITLE
Fix up the QtWebSockets module

### DIFF
--- a/PySide2/CMakeLists.txt
+++ b/PySide2/CMakeLists.txt
@@ -191,13 +191,7 @@ HAS_QT_MODULE(Qt5Qml_FOUND QtQml)
 HAS_QT_MODULE(Qt5QuickWidgets_FOUND QtQuickWidgets)
 HAS_QT_MODULE(Qt5WebEngineWidgets_FOUND QtWebEngineWidgets)
 HAS_QT_MODULE(Qt5WebChannel_FOUND QtWebChannel)
-if(0)
-    # Doesn't build yet, requires SSL classes in QtNetwork which
-    # Shiboken doesn't seem to pick up yet
-    HAS_QT_MODULE(Qt5WebSockets_FOUND QtWebSockets)
-else()
-    set(DISABLE_QtWebSockets 1 PARENT_SCOPE)
-endif()
+HAS_QT_MODULE(Qt5WebSockets_FOUND QtWebSockets)
 
 # install
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/__init__.py"

--- a/PySide2/QtWebSockets/typesystem_websockets.xml
+++ b/PySide2/QtWebSockets/typesystem_websockets.xml
@@ -22,12 +22,21 @@
   <load-typesystem name="typesystem_core.xml" generate="no"/>
   <load-typesystem name="typesystem_network.xml" generate="no"/>
 
+  <object-type name="QMaskGenerator" />
+
   <object-type name="QWebSocket">
     <extra-includes>
       <include file-name="QTcpSocket" location="global"/>
     </extra-includes>
   </object-type>
+
   <object-type name="QWebSocketCorsAuthenticator" />
+
+  <namespace-type name="QWebSocketProtocol">
+    <enum-type name="Version"/>
+    <enum-type name="CloseCode"/>
+  </namespace-type>
+
   <object-type name="QWebSocketServer">
     <enum-type name="SslMode" />
     <extra-includes>
@@ -35,4 +44,14 @@
     </extra-includes>
   </object-type>
 
+  <!-- TODO: Gracefully handle the lack of SSL support -->
+  <rejection class="QWebSocket" function-name="ignoreSslErrors" />
+  <rejection class="QWebSocket" function-name="setSslConfiguration" />
+  <rejection class="QWebSocket" function-name="sslConfiguration" />
+  <rejection class="QWebSocket" function-name="ignoreSslErrors" />
+  <rejection class="QWebSocket" function-name="sslErrors" />
+  <rejection class="QWebSocketServer" function-name="setSslConfiguration" />
+  <rejection class="QWebSocketServer" function-name="sslConfiguration" />
+  <rejection class="QWebSocketServer" function-name="peerVerifyError" />
+  <rejection class="QWebSocketServer" function-name="sslErrors" />
 </typesystem>

--- a/PySide2/global.h.in
+++ b/PySide2/global.h.in
@@ -439,11 +439,9 @@ QT_END_NAMESPACE
 #  include <QtWebChannel/QtWebChannel>
 #endif
 
-/** Doesn't build yet.
 #if @Qt5WebSockets_FOUND@
 #  include <QtWebSockets/QtWebSockets>
 #endif
-*/
 
 //QtHelp needs to be included after QtSql. Why?
 #include <QtHelp/QtHelp>


### PR DESCRIPTION
It now builds successfully (also added a missing class and namespace) - but the ssl-related functions needed to be rejected for now. For some reason, when building QtNetwork, Shiboken's not picking up the SSL-related classes like QSslConfiguration and it's causing this module to fail with those functions enabled.