### PR TITLE
Fix void return type on slots

### DIFF
--- a/libpyside/pysidemetafunction.cpp
+++ b/libpyside/pysidemetafunction.cpp
@@ -155,7 +155,7 @@ bool call(QObject* self, int methodIndex, PyObject* args, PyObject** retVal)
 
     // Prepare room for return type
     const char* returnType = method.typeName();
-    if (returnType)
+    if (returnType && std::strcmp("void", returnType))
         argTypes.prepend(returnType);
     else
         argTypes.prepend(QByteArray());

--- a/libpyside/signalmanager.cpp
+++ b/libpyside/signalmanager.cpp
@@ -469,7 +469,7 @@ int SignalManager::callPythonMetaMethod(const QMetaMethod& method, void** args, 
     if (pyArguments) {
         Shiboken::Conversions::SpecificConverter* retConverter = NULL;
         const char* returnType = method.typeName();
-        if (returnType && std::strcmp("", returnType)) {
+        if (returnType && std::strcmp("", returnType) && std::strcmp("void", returnType)) {
             retConverter = new Shiboken::Conversions::SpecificConverter(returnType);
             if (!retConverter || !*retConverter) {
                 PyErr_Format(PyExc_RuntimeError, "Can't find converter for '%s' to call Python meta method.", returnType);


### PR DESCRIPTION
This *should* fix slots that don't have a return type. I've yet to mess around much with the property decorator