### PR TITLE
Add basic automatic QJsonObject <-> dict conversion

### DIFF
--- a/PySide2/QtCore/CMakeLists.txt
+++ b/PySide2/QtCore/CMakeLists.txt
@@ -55,7 +55,8 @@ ${QtCore_GEN_DIR}/qgenericreturnargument_wrapper.cpp
 ${QtCore_GEN_DIR}/qhistorystate_wrapper.cpp
 ${QtCore_GEN_DIR}/qiodevice_wrapper.cpp
 ${QtCore_GEN_DIR}/qjsonarray_wrapper.cpp
-${QtCore_GEN_DIR}/qjsonobject_wrapper.cpp
+${QtCore_GEN_DIR}/qjsondocument_wrapper.cpp
+${QtCore_GEN_DIR}/qjsonparseerror_wrapper.cpp
 ${QtCore_GEN_DIR}/qjsonvalue_wrapper.cpp
 ${QtCore_GEN_DIR}/qitemselectionmodel_wrapper.cpp
 ${QtCore_GEN_DIR}/qlibraryinfo_wrapper.cpp

--- a/PySide2/QtCore/typesystem_core_common.xml
+++ b/PySide2/QtCore/typesystem_core_common.xml
@@ -590,6 +590,28 @@
     </conversion-rule>
   </primitive-type>
 
+  <primitive-type name="QJsonObject">
+    <conversion-rule>
+        <native-to-target>
+        // The QVariantMap returned by QJsonObject seems to cause a segfault, so
+        // using QJsonObject.toVariantMap() won't work.
+        // Wrapping it in a QJsonValue first allows it to work
+        QJsonValue val(%in);
+        QVariant ret = val.toVariant();
+
+        return %CONVERTTOPYTHON[QVariant](ret);
+        </native-to-target>
+        <target-to-native>
+            <add-conversion type="PyDict">
+            QVariant dict = QVariant_convertToVariantMap(%in);
+            QJsonValue val = QJsonValue::fromVariant(dict);
+
+            %out = val.toObject();
+            </add-conversion>
+        </target-to-native>
+    </conversion-rule>
+  </primitive-type>
+
   <primitive-type name="QModelIndexList">
     <include file-name="qabstractitemmodel.h" location="global"/>
     <conversion-rule>
@@ -3990,12 +4012,24 @@
       </inject-code>
     </add-function>
   </value-type>
+
   <value-type name="QJsonArray">
     <extra-includes>
       <include file-name="QStringList" location="global"/>
     </extra-includes>
   </value-type>
-  <value-type name="QJsonObject" />
+
+  <value-type name="QJsonDocument">
+    <enum-type name="DataValidation" />
+    <enum-type name="JsonFormat" />
+  </value-type>
+
+  <rejection class="QJsonDocument" field-name="BinaryFormatTag" />
+
+  <value-type name="QJsonParseError">
+    <enum-type name="Type"/>
+  </value-type>
+
   <value-type name="QJsonValue">
     <enum-type name="Type"/>
     <extra-includes>


### PR DESCRIPTION
Final bit of tweaking that was needed to get QWebChannel support working nicely.

Example: If you got this object from a page:

```json
{
    "hello": "world",
    "number": 123,
    "array": [1, 2, 3],
    "nullValue": null
}
```

You'll get this Python dict:

```python
{
    "hello": "world",
    "number": 123,
    "array": [1, 2, 3],
    "nullValue": None
}
```

The JSON classes have a to and from variant method, so this conversion just piggy backs off of pyside's existing Variant<>Python support.

And it turns a dict into a QJsonObject too! If you provide it with some none-serializable object, it will just get eaten up and turned into a null.