### PR TITLE
Ensure the GIL in globalPostRoutineCallback()

### DIFF
--- a/PySide2/QtCore/typesystem_core_common.xml
+++ b/PySide2/QtCore/typesystem_core_common.xml
@@ -957,6 +957,7 @@
     static QStack&lt;PyObject*&gt; globalPostRoutineFunctions;
     void globalPostRoutineCallback()
     {
+        Shiboken::GilState state;
         foreach(PyObject* callback, globalPostRoutineFunctions) {
             Shiboken::AutoDecRef result(PyObject_CallObject(callback, NULL));
             Py_DECREF(callback);


### PR DESCRIPTION
This fixes the segfault that causes the test `QtCore/bug_515.py` to fail.