### PR TITLE
Fix outdated module names in tests

### DIFF
--- a/tests/QtCore/bug_606.py
+++ b/tests/QtCore/bug_606.py
@@ -1,6 +1,6 @@
 import unittest
 
-import PySide
+import PySide2
 from PySide2.QtCore import QPoint, QPointF
 from PySide2.QtCore import QLine, QLineF
 from PySide2.QtCore import QSize, QSizeF

--- a/tests/QtCore/bug_826.py
+++ b/tests/QtCore/bug_826.py
@@ -1,5 +1,5 @@
 from PySide2.QtCore import QEvent, Qt
-import PySide
+import PySide2
 
 import unittest
 

--- a/tests/QtCore/repr_test.py
+++ b/tests/QtCore/repr_test.py
@@ -1,4 +1,4 @@
-import PySide
+import PySide2
 import unittest
 
 from PySide2.QtCore import QByteArray, QDate, QDateTime, QTime, QLine, QLineF

--- a/tests/QtCore/versioninfo_test.py
+++ b/tests/QtCore/versioninfo_test.py
@@ -1,10 +1,10 @@
 import unittest
-import PySide
+import PySide2
 
 class TestVersionInfo(unittest.TestCase):
     def testIt(self):
 
-        v = PySide.__version_info__
+        v = PySide2.__version_info__
         self.assertEqual(type(v), tuple)
         self.assertEqual(len(v), 5)
         self.assertEqual(type(v[0]), int)
@@ -13,7 +13,7 @@ class TestVersionInfo(unittest.TestCase):
         self.assertEqual(type(v[3]), str)
         self.assertEqual(type(v[4]), int)
 
-        self.assertEqual(type(PySide.__version__), str)
+        self.assertEqual(type(PySide2.__version__), str)
 
 
 if __name__ == '__main__':

--- a/tests/QtGui/bug_606.py
+++ b/tests/QtGui/bug_606.py
@@ -1,6 +1,6 @@
 import unittest
 
-import PySide
+import PySide2
 from PySide2.QtGui import QVector2D, QVector3D, QVector4D
 from PySide2.QtGui import QColor
 

--- a/tests/QtGui/qcolor_test.py
+++ b/tests/QtGui/qcolor_test.py
@@ -1,7 +1,7 @@
 
 import unittest
 import colorsys
-import PySide
+import PySide2
 
 from PySide2.QtCore import Qt
 from PySide2.QtGui import QColor

--- a/tests/QtGui/repr_test.py
+++ b/tests/QtGui/repr_test.py
@@ -1,7 +1,7 @@
 
 import unittest
 
-import PySide
+import PySide2
 from PySide2.QtCore import QPoint
 from PySide2.QtGui import QMatrix
 from PySide2.QtGui import QMatrix2x2, QMatrix2x3, QMatrix2x4

--- a/tests/pysidetest/utils_test.py
+++ b/tests/pysidetest/utils_test.py
@@ -24,7 +24,7 @@ import os
 
 
 if sys.platform == 'win32':
-    from PySide._utils import _get_win32_case_sensitive_name
+    from PySide2._utils import _get_win32_case_sensitive_name
 
     class Win32UtilsTest(unittest.TestCase):
         def testWin32CaseSensitiveName(self):

--- a/tests/tools/list-class-hierarchy.py
+++ b/tests/tools/list-class-hierarchy.py
@@ -26,10 +26,12 @@
 #
 # Usage:
 #
-# ./list-class-hierarchy.py PySide > pyside.list
-# ./list-class-hierarchy.py PyQt4 > pyqt4.list
+# ./list-class-hierarchy.py PySide2 > pyside2.list
+# ./list-class-hierarchy.py PyQt5 > pyqt5.list
 #
-# meld pyside.list pyqt4.list
+# meld pyside.list pyqt5.list
+
+from __future__ import print_function
 
 import sys
 import pdb
@@ -70,7 +72,7 @@ if __name__=='__main__':
                 'QtHelp',
                #'QtMultimedia',
                 'QtNetwork',
-                'QtOpenGL',
+               #'QtOpenGL',
                 'QtScript',
                 'QtScriptTools',
                 'QtSql',
@@ -85,7 +87,7 @@ if __name__=='__main__':
     librarySymbols = {}
     for l in libraries:
         dictionary = []
-        if l =="PyQt4":
+        if l =="PyQt5":
             import sip
             sip.setapi('QDate',2)
             sip.setapi('QDateTime',2)
@@ -96,12 +98,12 @@ if __name__=='__main__':
             sip.setapi('QVariant',2)
 
         for m in modules:
-            exec "from %s import %s" % (l,m) in globals(), locals()
+            exec("from %s import %s" % (l,m), globals(), locals())
             dictionary += recurse_into(m, eval(m))
         librarySymbols[l] = dictionary
 
-    print "PyQt4: ", len(librarySymbols["PyQt4"]), " PySide: ", len(librarySymbols["PySide"])
+    print("PyQt5: ", len(librarySymbols["PyQt5"]), " PySide2: ", len(librarySymbols["PySide2"]))
 
-    for symbol in librarySymbols["PyQt4"]:
-        if not (symbol in librarySymbols["PySide"]):
-            print "Symbol not found in PySide:", symbol
+    for symbol in librarySymbols["PyQt5"]:
+        if not (symbol in librarySymbols["PySide2"]):
+            print("Symbol not found in PySide2:", symbol)

--- a/tests/util/color.py
+++ b/tests/util/color.py
@@ -1,12 +1,13 @@
+from __future__ import print_function
 
 '''Function to print a colored line to terminal'''
 
 RED='\033[0;31m%s\033[m'
 
 def print_colored(message, color=RED):
-    print color % message
+    print(color % message)
 
 if __name__ == '__main__':
-    print '42 - the answer'
+    print('42 - the answer')
     print_colored("But what's the question?")
-    print 'Hum?'
+    print('Hum?')

--- a/tests/util/pyqt_diff.py
+++ b/tests/util/pyqt_diff.py
@@ -1,20 +1,21 @@
+from __future__ import print_function
 
-'''Script to show the difference between PyQt4 and ours'''
+'''Script to show the difference between PyQt5 and ours'''
 
 import sys
 
 from color import print_colored
 
 def check_module_diff(module_name):
-    '''Difference between PySide and PyQt4 versions of qt bindings.
-    Returns a tuple with the members present only on PySide and only on PyQt4'''
-    boost_module = getattr(__import__('PySide.' + module_name), module_name)
-    orig_module = getattr(__import__('PyQt4.' + module_name), module_name)
+    '''Difference between PySide2 and PyQt5 versions of qt bindings.
+    Returns a tuple with the members present only on PySide2 and only on PyQt5'''
+    shiboken_module = getattr(__import__('PySide2.' + module_name), module_name)
+    orig_module = getattr(__import__('PyQt5.' + module_name), module_name)
 
-    boost_set = set(dir(boost_module))
+    shiboken_set = set(dir(shiboken_module))
     orig_set = set(dir(orig_module))
 
-    return sorted(boost_set - orig_set), sorted(orig_set - boost_set)
+    return sorted(shiboken_set - orig_set), sorted(orig_set - shiboken_set)
 
 
 def main(argv=None):
@@ -23,13 +24,13 @@ def main(argv=None):
 
     module_name = argv[1] if len(argv) >= 2 else 'QtCore'
 
-    only_boost, only_orig = check_module_diff(module_name)
+    only_shiboken, only_orig = check_module_diff(module_name)
 
-    print_colored('Only on Boost version')
-    print only_boost
+    print_colored('Only on Shiboken version')
+    print(only_shiboken)
 
     print_colored('Only on SIP version')
-    print only_orig
+    print(only_orig)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
There were still some attempts to import `PySide` which was causing a couple of tests to fail. Also updated the PyQt<->PySide comparison tools