### PR TITLE
Fix missing tests

### DIFF
--- a/PySide2/CMakeLists.txt
+++ b/PySide2/CMakeLists.txt
@@ -43,6 +43,9 @@ macro(CHECK_PACKAGE_FOUND name)
     set(_name_found "${name}_FOUND")
     if(${_name_found})
         message("module ${name} found")
+
+        # Hoist this to the parent scope to make sure all tests get built
+        set("${name}_FOUND" 1 PARENT_SCOPE)
     else()
         if("${ARGN}" STREQUAL "opt")
             message(STATUS "optional module ${name} skipped")

--- a/tests/QtQml/bug_847.py
+++ b/tests/QtQml/bug_847.py
@@ -8,7 +8,7 @@ import unittest
 
 from helper import adjust_filename, UsesQApplication
 
-from PySide2.QtCore import Slot, Signal, QUrl
+from PySide2.QtCore import Slot, Signal, QUrl, QTimer, QCoreApplication
 from PySide2.QtQuick import QQuickView
 
 class View(QQuickView):
@@ -34,6 +34,7 @@ class TestQML(UsesQApplication):
         view = View()
         view.called.connect(self.done)
         view.show()
+        QTimer.singleShot(300, QCoreApplication.instance().quit)
         self.app.exec_()
         self.assertTrue(self._sucess)
 


### PR DESCRIPTION
Not all tests were getting picked up by the CMake file for the tests, because the variables being set by `find_package` in the `pyside2/PySide2` CMake file were not being hoisted to the parent scope.

The tests that were running already are running because other parts of the CMake script were doing things like `find_package(Qt5Core)` for other things.

This brings the number of tests from 356 to 390, and unfortunately the percentage of passing tests down from 81% to 78% :(

Also added a timeout to a Qml test because it hangs after a while.