### PR TITLE
Fix use-after-free in QProperty

### DIFF
--- a/libpyside/dynamicqmetaobject.cpp
+++ b/libpyside/dynamicqmetaobject.cpp
@@ -214,7 +214,8 @@ static bool isQRealType(const char *type)
 
 uint PropertyData::flags() const
 {
-    const char* typeName = type().data();
+    const QByteArray btype(type());
+    const char* typeName = btype.data();
     uint flags = Invalid;
     if (!isVariantType(typeName))
          flags |= EnumOrFlag;


### PR DESCRIPTION
This adds the following patch from the old PySide Gerrit:
https://codereview.qt-project.org/#/c/84452/

@pankajp's description of the patch:

> PropertyData::type() returns a new QByteArray (whose `data` is a
> copy of the `char*` name of the property)
> However the use of `type().data()` on the stack without saving
> its reference means the `char*` returned by the `data()` method
> is immediately deallocated in the the `~QByteArray` destructor.
> (Detected by AddressSanitizer)
> The attached patch fixes it by holding a reference to the
QByteArray returned by `type()` for the duration of the method call