### PR TITLE
Fix segfault when disconnecting signal on deleted object

### DIFF
--- a/libpyside/pysidesignal.cpp
+++ b/libpyside/pysidesignal.cpp
@@ -463,7 +463,7 @@ PyObject* signalInstanceDisconnect(PyObject* self, PyObject* args)
         Shiboken::AutoDecRef tupleArgs(PyList_AsTuple(pyArgs));
         Shiboken::AutoDecRef pyMethod(PyObject_GetAttrString(source->d->source, "disconnect"));
         PyObject* result = PyObject_CallObject(pyMethod, tupleArgs);
-        if (result == Py_True)
+        if (!result || result == Py_True)
             return result;
         else
             Py_DECREF(result);

--- a/tests/signals/CMakeLists.txt
+++ b/tests/signals/CMakeLists.txt
@@ -1,4 +1,5 @@
 PYSIDE_TEST(args_dont_match_test.py)
+PYSIDE_TEST(bug_186.py)
 PYSIDE_TEST(bug_311.py)
 PYSIDE_TEST(bug_312.py)
 PYSIDE_TEST(bug_319.py)

--- a/tests/signals/bug_189.py
+++ b/tests/signals/bug_189.py
@@ -1,0 +1,46 @@
+# This file is part of PySide: Python for Qt
+#
+# Copyright (C) 2013 Digia Plc and/or its subsidiary(-ies).
+#
+# Contact: PySide team <contact@pyside.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public License
+# version 2 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA
+
+import unittest
+from PySide import QtCore, QtGui
+from helper import UsesQApplication
+
+
+class TestBugPYSIDE189(UsesQApplication):
+
+    def testDisconnect(self):
+        # Disconnecting from a signal owned by a destroyed object
+        # should raise an exception, not segfault.
+        def onValueChanged(self, value):
+            pass
+
+        sld = QtGui.QSlider()
+        sld.valueChanged.connect(onValueChanged)
+
+        sld.deleteLater()
+
+        QtCore.QTimer.singleShot(0, self.app.quit)
+        self.app.exec_()
+
+        self.assertRaises(RuntimeError, sld.valueChanged.disconnect, onValueChanged)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/signals/bug_189.py
+++ b/tests/signals/bug_189.py
@@ -19,9 +19,9 @@
 # 02110-1301 USA
 
 import unittest
-from PySide import QtCore, QtGui
-from helper import UsesQApplication
 
+from PySide2 import QtCore, QtWidgets
+from helper import UsesQApplication
 
 class TestBugPYSIDE189(UsesQApplication):
 
@@ -31,7 +31,7 @@ class TestBugPYSIDE189(UsesQApplication):
         def onValueChanged(self, value):
             pass
 
-        sld = QtGui.QSlider()
+        sld = QtWidgets.QSlider()
         sld.valueChanged.connect(onValueChanged)
 
         sld.deleteLater()


### PR DESCRIPTION
This PR merges this patch from the old Gerrit (and also updates the unit test in it to PySide2):
https://codereview.qt-project.org/#/c/110414/

Original description:

> When disconnecting a signal on object that has been destroyed the
> disconnect call (Sbk_QObjectFunc_disconnect) fails and returns 0 with an
> error set. The calling function (signalInstanceDisconnect) was
> segfaulting because it decrements the reference count of the returned
> value. As the Python error is already set it's sufficient for
> signalInstanceDisconnect to return 0 in this case.

Pinging the original contributor, @tonyroberts, so he's aware of this.