### PR TITLE
Fix improper test filename

### DIFF
--- a/tests/signals/CMakeLists.txt
+++ b/tests/signals/CMakeLists.txt
@@ -1,5 +1,5 @@
 PYSIDE_TEST(args_dont_match_test.py)
-PYSIDE_TEST(bug_186.py)
+PYSIDE_TEST(bug_189.py)
 PYSIDE_TEST(bug_311.py)
 PYSIDE_TEST(bug_312.py)
 PYSIDE_TEST(bug_319.py)


### PR DESCRIPTION
I ran the test manually, so didn't catch that the name I put in the cmakelist was wrong.