### PR TITLE
Add no-argument overloads to application constructors

### DIFF
--- a/PySide2/QtCore/typesystem_core_common.xml
+++ b/PySide2/QtCore/typesystem_core_common.xml
@@ -3323,6 +3323,7 @@
     <!-- constructor documentation -->
     <inject-documentation format="target" mode="append">
 .. class:: QCoreApplication(args)
+.. class:: QCoreApplication()
 
     Constructs a Qt kernel application. Kernel applications are applications
     without a graphical user interface. These type of applications are used
@@ -3334,7 +3335,12 @@
     </inject-documentation>
     <add-function signature="QCoreApplication(PySequence)">
         <inject-code>
-            QCoreApplication_constructor(%PYSELF, args, &amp;%0);
+            QCoreApplicationConstructor(%PYSELF, %1, &amp;%0);
+        </inject-code>
+    </add-function>
+    <add-function signature="QCoreApplication()">
+        <inject-code>
+            QCoreApplicationConstructor(%PYSELF, args, &amp;%0);
         </inject-code>
     </add-function>
     <!-- blocking functions -->

--- a/PySide2/QtGui/glue/qguiapplication_init.cpp
+++ b/PySide2/QtGui/glue/qguiapplication_init.cpp
@@ -1,6 +1,4 @@
-// Borrowed reference to QtGui module
-extern PyObject* moduleQtGui;
-
+// Global variables used to store argc and argv values
 static int QGuiApplicationArgCount;
 static char** QGuiApplicationArgValues;
 

--- a/PySide2/QtGui/typesystem_gui_common.xml
+++ b/PySide2/QtGui/typesystem_gui_common.xml
@@ -3270,6 +3270,11 @@
             QGuiApplicationConstructor(%PYSELF, %1, &amp;%0);
         </inject-code>
     </add-function>
+    <add-function signature="QGuiApplication()">
+        <inject-code>
+            QGuiApplicationConstructor(%PYSELF, args, &amp;%0);
+        </inject-code>
+    </add-function>
     <modify-function signature="exec()" rename="exec_" allow-thread="yes"/>
     <inject-code class="native" file="glue/qguiapplication_init.cpp" position="beginning" />
 

--- a/PySide2/QtWidgets/typesystem_widgets_common.xml
+++ b/PySide2/QtWidgets/typesystem_widgets_common.xml
@@ -3118,6 +3118,11 @@
             QApplicationConstructor(%PYSELF, %1, &amp;%0);
         </inject-code>
     </add-function>
+    <add-function signature="QApplication()">
+        <inject-code>
+            QApplicationConstructor(%PYSELF, args, &amp;%0);
+        </inject-code>
+    </add-function>
     <modify-function signature="exec()" rename="exec_" allow-thread="yes"/>
     <inject-code class="native" file="glue/qapplication_init.cpp" position="beginning" />
 


### PR DESCRIPTION
This is a *really* minor PR adds a small convenience overload to the application constructors without needing to provide a list/tuple to them. 

```py
# You could do this:
app = QApplication()

# Rather than this:
app = QApplication([])
```

I personally rarely find myself needing to pass args to these constructors, so this has been something I've kinda wanted.

Also updated the glue for `QCoreApplication` to be more like the glue for the other constructors, to make future tweaks to all their glue easier. In the future, I'd like to actually add support for kwargs as an alternative to having to provide an awkward list of strings to the constructors but that effort would be non-trivial.