### PR TITLE
Fix private API usage for Qt 5.6

### DIFF
--- a/libpyside/signalmanager.cpp.in
+++ b/libpyside/signalmanager.cpp.in
@@ -474,7 +474,12 @@ int SignalManager::qt_metacall(QObject* object, QMetaObject::Call call, int id, 
 
             if (data || !data->jsWrapper.isNullOrUndefined()) {
                 QV4::ExecutionEngine *engine = data->jsWrapper.engine();
+
+                #if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
                 QV4::Heap::ExecutionContext *ctx = engine->current;
+                #else
+                QV4::Heap::ExecutionContext *ctx = engine->currentContext();
+                #endif
 
                 if (ctx->type == QV4::Heap::ExecutionContext::ContextType::Type_CallContext ||
                     ctx->type == QV4::Heap::ExecutionContext::ContextType::Type_SimpleCallContext) {

--- a/libpyside/signalmanager.cpp.in
+++ b/libpyside/signalmanager.cpp.in
@@ -474,7 +474,7 @@ int SignalManager::qt_metacall(QObject* object, QMetaObject::Call call, int id, 
 
             if (data || !data->jsWrapper.isNullOrUndefined()) {
                 QV4::ExecutionEngine *engine = data->jsWrapper.engine();
-                QV4::Heap::ExecutionContext *ctx = engine->currentContext();
+                QV4::Heap::ExecutionContext *ctx = engine->current;
 
                 if (ctx->type == QV4::Heap::ExecutionContext::ContextType::Type_CallContext ||
                     ctx->type == QV4::Heap::ExecutionContext::ContextType::Type_SimpleCallContext) {


### PR DESCRIPTION
The private APIs changed around a little bit in Qt 5.6. `currentContext()` is no longer a function and does something else, but the member `current` is the same on 5.6 and older versions.