### PR TITLE
Header <QtDesigner/QDesignerCustomWidgetInterface> is deprecated in Qt5.5.

### DIFF
--- a/plugins/customwidget.cpp
+++ b/plugins/customwidget.cpp
@@ -23,7 +23,6 @@
 
 #include "customwidget.h"
 
-#include <shiboken.h>
 
 struct PyCustomWidgetPrivate
 {

--- a/plugins/customwidget.h
+++ b/plugins/customwidget.h
@@ -24,15 +24,14 @@
 #define _PY_CUSTOM_WIDGET_H_
 
 #include <shiboken.h>
-#include <QtDesigner/QtDesigner>
-#include <QDesignerCustomWidgetInterface>
 
-// Qt5: no idea why this definition is not found automatically! It should come
-// from <QDesignerCustomWidgetInterface> which resolves to Qt5's customwidget.h
-#ifdef Q_MOC_RUN
-Q_DECLARE_INTERFACE(QDesignerCustomWidgetInterface, 
-                    "org.qt-project.Qt.QDesignerCustomWidgetInterface")
+#include <QtCore/QtGlobal>
+#if (QT_VERSION < QT_VERSION_CHECK(5, 5, 0))
+ #include <QtDesigner/QDesignerCustomWidgetInterface>
+#else
+ #include <QtUiPlugin/QDesignerCustomWidgetInterface>
 #endif
+
 
 struct PyCustomWidgetPrivate;
 

--- a/plugins/customwidgets.cpp
+++ b/plugins/customwidgets.cpp
@@ -23,7 +23,6 @@
 #include "customwidget.h"
 #include "customwidgets.h"
 
-#include <shiboken.h>
 
 struct PyCustomWidgetPrivate
 {

--- a/plugins/customwidgets.h
+++ b/plugins/customwidgets.h
@@ -24,18 +24,14 @@
 #define _PY_CUSTOM_WIDGETS_H_
 
 #include <shiboken.h>
-#include <customwidget.h>
 
-#include <QtDesigner/QtDesigner>
-#include <QtPlugin>
-#include <QDesignerCustomWidgetInterface>
-
-// Qt5: no idea why this definition is not found automatically! It should come
-// from <QDesignerCustomWidgetInterface> which resolves to Qt5's customwidget.h
-#ifdef Q_MOC_RUN
-Q_DECLARE_INTERFACE(QDesignerCustomWidgetCollectionInterface, 
-                    "org.qt-project.Qt.QDesignerCustomWidgetCollectionInterface")
+#include <QtCore/QtGlobal>
+#if (QT_VERSION < QT_VERSION_CHECK(5, 5, 0))
+ #include <QtDesigner/QDesignerCustomWidgetInterface>
+#else
+ #include <QtUiPlugin/QDesignerCustomWidgetInterface>
 #endif
+
 
 struct PyCustomWidgetsPrivate;
 


### PR DESCRIPTION
Use QtUiPlugin/QDesignerCustomWidgetInterface instead.