### PR TITLE
Fix building signalmanager.cpp with Qt < 5.5.0.

### DIFF
--- a/libpyside/signalmanager.cpp.in
+++ b/libpyside/signalmanager.cpp.in
@@ -475,14 +475,21 @@ int SignalManager::qt_metacall(QObject* object, QMetaObject::Call call, int id, 
             if (data || !data->jsWrapper.isNullOrUndefined()) {
                 QV4::ExecutionEngine *engine = data->jsWrapper.engine();
 
-                #if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
+#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
                 QV4::Heap::ExecutionContext *ctx = engine->current;
-                #else
+#elif QT_VERSION >= QT_VERSION_CHECK(5, 5, 0)
                 QV4::Heap::ExecutionContext *ctx = engine->currentContext();
-                #endif
+#else
+                QV4::ExecutionContext *ctx = engine->currentContext();
+#endif
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 5, 0)
                 if (ctx->type == QV4::Heap::ExecutionContext::Type_CallContext ||
                     ctx->type == QV4::Heap::ExecutionContext::Type_SimpleCallContext) {
+#else
+                if (ctx->type == QV4::ExecutionContext::Type_CallContext ||
+                    ctx->type == QV4::ExecutionContext::Type_SimpleCallContext) {
+#endif
                     PyObject *errType, *errValue, *errTraceback;
                     PyErr_Fetch(&errType, &errValue, &errTraceback);
                     PyErr_Restore(errType, errValue, errTraceback);
@@ -491,6 +498,7 @@ int SignalManager::qt_metacall(QObject* object, QMetaObject::Call call, int id, 
 
                     PyErr_Print();
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 5, 0)
                     if (errType == PyExc_SyntaxError) {
                         return engine->throwSyntaxError(errString);
                     } else if (errType == PyExc_TypeError) {
@@ -498,6 +506,15 @@ int SignalManager::qt_metacall(QObject* object, QMetaObject::Call call, int id, 
                     } else {
                         return engine->throwError(errString);
                     }
+#else
+                    if (errType == PyExc_SyntaxError) {
+                        return ctx->throwSyntaxError(errString);
+                    } else if (errType == PyExc_TypeError) {
+                        return ctx->throwTypeError(errString);
+                    } else {
+                        return ctx->throwError(errString);
+                    }
+#endif
                 }
             }
 #endif


### PR DESCRIPTION
1. Heap namespace has been introduced in Qt 5.5.0.
2. Throw methods have been moved from ExecutionContext to ExecutionEngine in Qt 5.5.0.

Source 1: https://github.com/qtproject/qtdeclarative/commit/84aae25c0b3003fb846568cf26a2c7150db14d9d
Source 2: https://github.com/qtproject/qtdeclarative/commit/486948817b26da2c62802bb93a0f671715c609d4

Tested on Debian only.
GCC 4.9.2 and Qt 5.3.2
GCC 5.3.1 and Qt 5.5.1

Cheers,
Mateusz