### PR TITLE
Fix building signalmanager.cpp with Qt 5.4.x.

### DIFF
--- a/libpyside/signalmanager.cpp.in
+++ b/libpyside/signalmanager.cpp.in
@@ -486,6 +486,9 @@ int SignalManager::qt_metacall(QObject* object, QMetaObject::Call call, int id, 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 5, 0)
                 if (ctx->type == QV4::Heap::ExecutionContext::Type_CallContext ||
                     ctx->type == QV4::Heap::ExecutionContext::Type_SimpleCallContext) {
+#elif QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+                if (ctx->d()->type == QV4::ExecutionContext::Type_CallContext ||
+                    ctx->d()->type == QV4::ExecutionContext::Type_SimpleCallContext) {
 #else
                 if (ctx->type == QV4::ExecutionContext::Type_CallContext ||
                     ctx->type == QV4::ExecutionContext::Type_SimpleCallContext) {


### PR DESCRIPTION
Hi,
compilation tested on:

Debian GCC 4.9.2 and Qt 5.3.2
Ubuntu GCC 5.2.1 and Qt 5.4.2
Debian GCC 5.3.1 and Qt 5.5.1

Cheers,
Mateusz