### PR TITLE
Add support for Qt X11 Extras module.

### DIFF
--- a/PySide2/CMakeLists.txt
+++ b/PySide2/CMakeLists.txt
@@ -29,6 +29,10 @@ find_package(Qt5WebEngineWidgets)
 find_package(Qt5WebChannel)
 find_package(Qt5WebSockets)
 
+if(UNIX AND NOT APPLE)
+  find_package(Qt5X11Extras) # new in Qt5, from QtGui
+endif()
+
 # Configure include based on platform
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/global.h.in"
                "${CMAKE_CURRENT_BINARY_DIR}/pyside2_global.h" @ONLY)
@@ -129,6 +133,10 @@ CHECK_PACKAGE_FOUND(Qt5WebEngineWidgets opt)
 CHECK_PACKAGE_FOUND(Qt5WebChannel opt)
 CHECK_PACKAGE_FOUND(Qt5WebSockets opt)
 
+if(UNIX AND NOT APPLE)
+  check_package_found(Qt5X11Extras)
+endif()
+
 # note: the order of this list is relevant for dependencies.
 # For instance: Qt5Printsupport must come before Qt5WebKitWidgets
 HAS_QT_MODULE(Qt5Core_FOUND QtCore)
@@ -195,6 +203,10 @@ HAS_QT_MODULE(Qt5QuickWidgets_FOUND QtQuickWidgets)
 HAS_QT_MODULE(Qt5WebEngineWidgets_FOUND QtWebEngineWidgets)
 HAS_QT_MODULE(Qt5WebChannel_FOUND QtWebChannel)
 HAS_QT_MODULE(Qt5WebSockets_FOUND QtWebSockets)
+
+if(UNIX AND NOT APPLE)
+    has_qt_module(Qt5X11Extras_FOUND QtX11Extras)
+endif()
 
 # install
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/__init__.py"

--- a/PySide2/QtGui/CMakeLists.txt
+++ b/PySide2/QtGui/CMakeLists.txt
@@ -1,15 +1,5 @@
 project(QtGui)
 
-if(ENABLE_X11)
-    message(WARNING "Qt X11 Extras don't get generated. Skipping them for now...")
-#    set(SPECIFIC_OS_FILES
-#        ${QtGui_GEN_DIR}/qx11info_wrapper.cpp
-#        ${QtGui_GEN_DIR}/qx11embedcontainer_wrapper.cpp
-#        ${QtGui_GEN_DIR}/qx11embedwidget_wrapper.cpp
-#    )
-
-endif()
-
 qt5_wrap_cpp(QPYTEXTOBJECT_MOC "${pyside2_SOURCE_DIR}/qpytextobject.h")
 
 set(QtGui_SRC
@@ -156,7 +146,6 @@ ${QtGui_GEN_DIR}/qwheelevent_wrapper.cpp
 ${QtGui_GEN_DIR}/qwindow_wrapper.cpp
 ${QtGui_GEN_DIR}/qwindowstatechangeevent_wrapper.cpp
 
-${SPECIFIC_OS_FILES}
 # module is always needed
 ${QtGui_GEN_DIR}/qtgui_module_wrapper.cpp
 )

--- a/PySide2/QtWidgets/typesystem_widgets_x11.xml
+++ b/PySide2/QtWidgets/typesystem_widgets_x11.xml
@@ -20,31 +20,6 @@
 -->
 <typesystem package="PySide2.QtWidgets">
 
-  <rejection class="" function-name="qt_x11_getX11InfoForWindow"/>
-  <rejection class="QX11Info" field-name="x11data"/>
-  <value-type name="QX11Info">
-    <add-function signature="display()" return-type="unsigned long" static="yes">
-        <inject-code>
-            %PYARG_0 = PyLong_FromVoidPtr(%TYPE::%FUNCTION_NAME());
-        </inject-code>
-    </add-function>
-    <modify-function signature="visual()const">
-        <inject-code>
-            %PYARG_0 = PyLong_FromVoidPtr(%CPPSELF.%FUNCTION_NAME());
-        </inject-code>
-    </modify-function>
-    <modify-function signature="appVisual(int)">
-        <inject-code>
-            %PYARG_0 = PyLong_FromVoidPtr(%CPPSELF.%FUNCTION_NAME());
-        </inject-code>
-    </modify-function>
-  </value-type>
-  <object-type name="QX11EmbedContainer">
-    <enum-type name="Error"/>
-  </object-type>
-  <object-type name="QX11EmbedWidget">
-    <enum-type name="Error"/>
-  </object-type>
-
   <enum-type name="QPixmap::ShareMode"/>
+
 </typesystem>

--- a/PySide2/QtX11Extras/CMakeLists.txt
+++ b/PySide2/QtX11Extras/CMakeLists.txt
@@ -1,0 +1,40 @@
+project(QtX11Extras)
+
+set(QtX11Extras_SRC
+${QtX11Extras_GEN_DIR}/qx11info_wrapper.cpp
+# module is always needed
+${QtX11Extras_GEN_DIR}/qtx11extras_module_wrapper.cpp
+)
+
+make_path(QtX11Extras_typesystem_path ${QtX11Extras_SOURCE_DIR}
+                                      ${QtCore_SOURCE_DIR}
+                                      ${QtCore_BINARY_DIR}
+                                      ${QtGui_SOURCE_DIR}
+                                      ${QtGui_BINARY_DIR})
+
+set(QtX11Extras_include_dirs ${QtX11Extras_SOURCE_DIR}
+                        ${QtX11Extras_BINARY_DIR}
+                        ${Qt5X11Extras_INCLUDE_DIRS}
+                        ${Qt5Core_INCLUDE_DIRS}
+                        ${Qt5Gui_INCLUDE_DIRS}
+                        ${QtCore_GEN_DIR}
+                        ${QtGui_GEN_DIR}
+                        ${SHIBOKEN_PYTHON_INCLUDE_DIR}
+                        ${SHIBOKEN_INCLUDE_DIR}
+                        ${libpyside_SOURCE_DIR})
+
+set(QtX11Extras_libraries pyside2
+                        ${Qt5X11Extras_LIBRARIES}
+                        ${SHIBOKEN_PYTHON_LIBRARIES}
+                        ${Qt5Core_LIBRARIES}
+                        ${Qt5Gui_LIBRARIES})
+
+set(QtX11Extras_deps QtCore QtGui)
+
+create_pyside_module(QtX11Extras
+                     QtX11Extras_include_dirs
+                     QtX11Extras_libraries
+                     QtX11Extras_deps
+                     QtX11Extras_typesystem_path
+                     QtX11Extras_SRC
+                     "")

--- a/PySide2/QtX11Extras/typesystem_x11extras.xml
+++ b/PySide2/QtX11Extras/typesystem_x11extras.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0"?>
 <!--
     This file is part of PySide project.
-    Copyright (C) 2013 Digia Plc and/or its subsidiary(-ies).
-    Contact: PySide team <contact@pyside.org>
+    Copyright (C) 2016 Mateusz Skowroński <skowri@gmail.com>
 
     This library is free software; you can redistribute it and/or
     modify it under the terms of the GNU Lesser General Public
@@ -18,8 +17,8 @@
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 -->
-<typesystem package="PySide2.QtGui">
+<typesystem package="PySide2.QtX11Extras">
+    <load-typesystem name="typesystem_core.xml" generate="no"/>
 
-  <enum-type name="QPixmap::ShareMode"/>
-
+    <object-type name="QX11Info" />
 </typesystem>

--- a/PySide2/global.h.in
+++ b/PySide2/global.h.in
@@ -385,9 +385,9 @@ QT_END_NAMESPACE
 #include <QtGui/QtGui>
 #include "qpytextobject.h"  // PySide class
 #if @ENABLE_X11@
-  #include <QtGui/QX11Info>
-  #include <QtGui/QX11EmbedContainer>
-  #include <QtGui/QX11EmbedWidget>
+#if @Qt5X11Extras_FOUND@
+#include <QtX11Extras/QX11Info>
+#endif
 #elif @ENABLE_MAC@
   #include <QtGui/qmacstyle_mac.h>
 #endif
@@ -450,4 +450,3 @@ QT_END_NAMESPACE
 #include <@GL_H@>
 #include <@QT_QTOPENGL_INCLUDE_DIR@/QtOpenGL>
 #endif // QT_NO_OPENGL
-


### PR DESCRIPTION
Debian based systems need libqt5x11extras5-dev package installed.

Debian GCC 4.9.2, Qt 5.3.2, Python 2.7.9 64-bit 
Ubuntu GCC 5.2.1, Qt 5.4.2, Python 2.7.10 64-bit
Debian GCC 5.3.1, Qt 5.5.1, Python 2.7.11 64-bit

Cheers,
Mateusz