### PR TITLE
Qt5X11Extras becomes optional. make command upper case.

### DIFF
--- a/PySide2/CMakeLists.txt
+++ b/PySide2/CMakeLists.txt
@@ -134,7 +134,7 @@ CHECK_PACKAGE_FOUND(Qt5WebChannel opt)
 CHECK_PACKAGE_FOUND(Qt5WebSockets opt)
 
 if(UNIX AND NOT APPLE)
-  check_package_found(Qt5X11Extras)
+  CHECK_PACKAGE_FOUND(Qt5X11Extras opt)
 endif()
 
 # note: the order of this list is relevant for dependencies.


### PR DESCRIPTION
X11Extras module is not required on linux. There are at least two cases:
    X11 is not installed, for example, on some embeded linux, linux using wayland instead of X11, or all custom Qt QPA backend (see "-platform" when building qt-base)
    X11 is installed but Qt5 X11Extra is not installed. It is the case for example if only qt-base is built

Use upper case to respect convention used in all previous calls of CHECK_PACKAGE_FOUND